### PR TITLE
Add a podspec for Cocoapods

### DIFF
--- a/sdk/iOS/src/WindowsAzureMobileServices.podspec
+++ b/sdk/iOS/src/WindowsAzureMobileServices.podspec
@@ -1,9 +1,9 @@
 Pod::Spec.new do |s|
-  s.name         = "MSAzureMobileServices"
-  s.version      = "0.0.1"
+  s.name         = "WindowsAzureMobileServices"
+  s.version      = "0.0.2"
   s.summary      = "Client SDKs and Samples for Windows Azure Mobile Services"
   s.homepage     = "https://www.windowsazure.com/en-us/develop/mobile/"
-  s.license      = 'MIT'
+  s.license      = 'Apache 2'
 
   s.author       = 'Windows Azure Team'
 
@@ -12,5 +12,4 @@ Pod::Spec.new do |s|
   s.source_files = 'sdk/iOS/src/**/*.{h,m}'
 
   s.requires_arc = true
-
 end


### PR DESCRIPTION
The [current podspec](https://github.com/jrossano/WindowsAzureMobileService) that exists in the CocoaPods specs repository pulls in the framework directly instead of compiling classes.

I'm not sure if this is an "official" version or not, but compiling from source would be preferred since we have it available.  (Not to mention I couldn't get the other pod to work).

This podspec works well for me.

Also includes the suggested rename & correct license.
