### PR TITLE
Add progress bar to WinPhone Login UI

### DIFF
--- a/sdk/Managed/.gitignore
+++ b/sdk/Managed/.gitignore
@@ -4,3 +4,4 @@
 bin
 obj
 packages/*
+.nuget/nuget.exe

--- a/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices.WindowsPhone8.UI/LoginPage.xaml
+++ b/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices.WindowsPhone8.UI/LoginPage.xaml
@@ -22,7 +22,13 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 
     <!--LayoutRoot is the root grid where all page content is placed-->
     <Grid x:Name="LayoutRoot" Background="Transparent">
-        <phone:WebBrowser x:Name="browserControl" IsScriptEnabled="True"/>
+        <ProgressBar 
+            x:Name="progress"  
+            IsIndeterminate="True" />
+        <phone:WebBrowser 
+            x:Name="browserControl" 
+            IsScriptEnabled="True" 
+            Visibility="Collapsed" />
     </Grid>
 
 </phone:PhoneApplicationPage>

--- a/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices.WindowsPhone8.UI/LoginPage.xaml.cs
+++ b/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices.WindowsPhone8.UI/LoginPage.xaml.cs
@@ -36,7 +36,17 @@ namespace Microsoft.WindowsAzure.MobileServices
 
             BackKeyPress += LoginPage_BackKeyPress;
             browserControl.Navigating += BrowserControl_Navigating;
+            browserControl.LoadCompleted += BrowserControl_LoadCompleted;
             browserControl.NavigationFailed += BrowserControl_NavigationFailed;
+        }
+
+        /// <summary>
+        /// Handler for the browser control's load completed event.  We use this to detect when
+        /// to hide the progress bar and show the browser control.
+        /// </summary>
+        void BrowserControl_LoadCompleted(object sender, NavigationEventArgs e)
+        {
+            HideProgressBar();
         }
 
         /// <summary>
@@ -95,6 +105,8 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// </summary>
         void LoginPage_BackKeyPress(object sender, System.ComponentModel.CancelEventArgs e)
         {
+            ShowProgressBar();
+
             responseData = "";
             responseStatus = PhoneAuthenticationStatus.UserCancel;
 
@@ -115,7 +127,7 @@ namespace Microsoft.WindowsAzure.MobileServices
                 authenticationFinished = true;
 
                 // Navigate back now.
-                browserControl.Source = new Uri("about:blank");
+                ShowProgressBar();
                 NavigationService.GoBack();
             }
         }
@@ -143,8 +155,26 @@ namespace Microsoft.WindowsAzure.MobileServices
             e.Handled = true;
 
             // Navigate back now.
-            browserControl.Source = new Uri("about:blank");
+            ShowProgressBar();
             NavigationService.GoBack();
+        }
+
+        /// <summary>
+        /// Shows the progress bar and hides the browser control.
+        /// </summary>
+        private void ShowProgressBar()
+        {
+            browserControl.Visibility = System.Windows.Visibility.Collapsed;
+            progress.Visibility = System.Windows.Visibility.Visible;
+        }
+
+        /// <summary>
+        /// Hides the progress bar and shows the browser control.
+        /// </summary>
+        private void HideProgressBar()
+        {
+            browserControl.Visibility = System.Windows.Visibility.Visible;
+            progress.Visibility = System.Windows.Visibility.Collapsed;
         }
     }
 }

--- a/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.Test/UnitTests/MobileServiceClient.Test.cs
+++ b/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.Test/UnitTests/MobileServiceClient.Test.cs
@@ -15,7 +15,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
 {
     [Tag("unit")]
     [Tag("client")]
-    class MobileServiceClientTests : TestBase
+    public class MobileServiceClientTests : TestBase
     {
         /// <summary>
         /// Verify we have an installation ID created whenever we use a ZUMO

--- a/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.Test/UnitTests/Table/MobileServiceTable.Generic.Test.cs
+++ b/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.Test/UnitTests/Table/MobileServiceTable.Generic.Test.cs
@@ -18,7 +18,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
     [Tag("service")]
     [Tag("unit")]
     [Tag("table")]
-    class MobileServiceTableGenericTests :TestBase
+    public class MobileServiceTableGenericTests :TestBase
     {
         [AsyncTestMethod]
         public async Task ReadAsyncGeneric()

--- a/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.Test/UnitTests/Table/MobileServiceTable.Test.cs
+++ b/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.Test/UnitTests/Table/MobileServiceTable.Test.cs
@@ -18,7 +18,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
     [Tag("service")]
     [Tag("unit")]
     [Tag("table")]
-    class MobileServiceTableTests : TestBase
+    public class MobileServiceTableTests : TestBase
     {
         [AsyncTestMethod]
         public async Task ReadAsync()


### PR DESCRIPTION
This is a fix for an issue that multiple customers have complained about regarding the login UI on Windows Phone. From Jeff Sanders: On Windows Phone the LoginAsync displays a blank white HTML page while connecting to the login provider.  This confuses developers and users and seems like there is something wrong.  It is very simple to add a progress bar and display the HTML only after it has loaded to fix this.
