### PR TITLE
[Android E2E Test App] Update logging to unify with other platforms

### DIFF
--- a/test/Android/ZumoE2ETestApp/src/com/microsoft/windowsazure/mobileservices/zumoe2etestapp/MainActivity.java
+++ b/test/Android/ZumoE2ETestApp/src/com/microsoft/windowsazure/mobileservices/zumoe2etestapp/MainActivity.java
@@ -21,6 +21,8 @@ package com.microsoft.windowsazure.mobileservices.zumoe2etestapp;
 
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import org.apache.http.client.methods.HttpPost;
@@ -49,10 +51,12 @@ import android.widget.ListView;
 import android.widget.Spinner;
 
 import com.microsoft.windowsazure.mobileservices.MobileServiceClient;
+import com.microsoft.windowsazure.mobileservices.zumoe2etestapp.framework.CompositeTestGroup;
 import com.microsoft.windowsazure.mobileservices.zumoe2etestapp.framework.TestCase;
 import com.microsoft.windowsazure.mobileservices.zumoe2etestapp.framework.TestExecutionCallback;
 import com.microsoft.windowsazure.mobileservices.zumoe2etestapp.framework.TestGroup;
 import com.microsoft.windowsazure.mobileservices.zumoe2etestapp.framework.TestResult;
+import com.microsoft.windowsazure.mobileservices.zumoe2etestapp.framework.Util;
 import com.microsoft.windowsazure.mobileservices.zumoe2etestapp.tests.CustomApiTests;
 import com.microsoft.windowsazure.mobileservices.zumoe2etestapp.tests.LoginTests;
 import com.microsoft.windowsazure.mobileservices.zumoe2etestapp.tests.MiscTests;
@@ -133,6 +137,28 @@ public class MainActivity extends Activity {
 		adapter.add(new MiscTests());
 		adapter.add(new PushTests());
 		adapter.add(new CustomApiTests());
+
+		ArrayList<TestCase> allTests = new ArrayList<TestCase>();
+		ArrayList<TestCase> allUnattendedTests = new ArrayList<TestCase>();
+		for (int i = 0; i < adapter.getCount(); i++) {
+			TestGroup group = adapter.getItem(i);
+			allTests.add(Util.createSeparatorTest("Start of group: " + group.getName()));
+			allUnattendedTests.add(Util.createSeparatorTest("Start of group: " + group.getName()));
+			
+			List<TestCase> testsForGroup = group.getTestCases();
+			for (TestCase test : testsForGroup) {
+				allTests.add(test);
+				if (test.canRunUnattended()) {
+					allUnattendedTests.add(test);
+				}
+			}
+			allTests.add(Util.createSeparatorTest("------------------"));
+			allUnattendedTests.add(Util.createSeparatorTest("------------------"));
+		}
+		
+		adapter.add(new CompositeTestGroup(TestGroup.AllUnattendedTestsGroupName, allUnattendedTests));
+		adapter.add(new CompositeTestGroup(TestGroup.AllTestsGroupName, allTests));
+		
 		mTestGroupSpinner.setSelection(0);
 		selectTestGroup(0);
 	}
@@ -262,14 +288,15 @@ public class MainActivity extends Activity {
 		}
 
 		TestGroup group = (TestGroup) mTestGroupSpinner.getSelectedItem();
-
+		logWithTimestamp(new Date(), "Tests for group \'" + group.getName() + "\'");
+		logSeparator();
 		group.runTests(client, new TestExecutionCallback() {
 
 			@Override
 			public void onTestStart(TestCase test) {
 				TestCaseAdapter adapter = (TestCaseAdapter) mTestCaseList.getAdapter();
 				adapter.notifyDataSetChanged();
-				log("TEST START", test.getName());
+				// log("TEST START", test.getName());
 			}
 
 			@Override
@@ -281,7 +308,6 @@ public class MainActivity extends Activity {
 			@Override
 			public void onTestComplete(TestCase test, TestResult result) {
 				Throwable e = result.getException();
-				String exMessage = "-";
 				if (e != null) {
 					StringBuilder sb = new StringBuilder();
 					while (e != null) {
@@ -291,7 +317,7 @@ public class MainActivity extends Activity {
 						e = e.getCause();
 					}
 
-					exMessage = sb.toString();
+					test.log("Exception: " + sb.toString());
 				}
 
 				final TestCaseAdapter adapter = (TestCaseAdapter) mTestCaseList.getAdapter();
@@ -305,8 +331,17 @@ public class MainActivity extends Activity {
 					}
 					
 				});
-				log("TEST LOG", test.getLog());
-				log("TEST COMPLETED", test.getName() + " - " + result.getStatus().toString() + " - Ex: " + exMessage);
+				logWithTimestamp(test.getStartTime(), "Logs for test " + test.getName() + " (" + result.getStatus().toString() + ")");
+				String testLogs = test.getLog();
+				if (testLogs.length() > 0) {
+					if (testLogs.endsWith("\n")) {
+						testLogs = testLogs.substring(0, testLogs.length() - 1);
+					}
+					log(testLogs);
+				}
+				
+				logWithTimestamp(test.getEndTime(), "Test " + result.getStatus().toString());
+				logWithTimestamp(test.getEndTime(), "-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-");
 				logSeparator();
 			}
 		});
@@ -319,16 +354,19 @@ public class MainActivity extends Activity {
 		mLog.append("\n");
 	}
 	
-	@SuppressWarnings("unused")
 	private void log(String content) {
 		log("Info", content);
+	}
+
+	private void logWithTimestamp(Date time, String content) {
+		log("Info", "[" + Util.dateToString(time, Util.LogTimeFormat) + "] " + content);
 	}
 
 	private void log(String title, String content) {
 		String message = title + " - " + content;
 		Log.d("ZUMO-E2ETESTAPP", message);
 
-		mLog.append(message);
+		mLog.append(content);
 		mLog.append('\n');
 	}
 

--- a/test/Android/ZumoE2ETestApp/src/com/microsoft/windowsazure/mobileservices/zumoe2etestapp/framework/CompositeTestGroup.java
+++ b/test/Android/ZumoE2ETestApp/src/com/microsoft/windowsazure/mobileservices/zumoe2etestapp/framework/CompositeTestGroup.java
@@ -1,0 +1,34 @@
+/*
+Copyright (c) Microsoft Open Technologies, Inc.
+All Rights Reserved
+Apache 2.0 License
+ 
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+     http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ 
+See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
+ */
+package com.microsoft.windowsazure.mobileservices.zumoe2etestapp.framework;
+
+import java.util.List;
+
+public class CompositeTestGroup extends TestGroup {
+
+	public CompositeTestGroup(String name, List<TestCase> testCases) {
+		super(name);
+		
+		for (TestCase test : testCases) {
+			this.addTest(test);
+		}
+	}
+
+}

--- a/test/Android/ZumoE2ETestApp/src/com/microsoft/windowsazure/mobileservices/zumoe2etestapp/framework/TestGroup.java
+++ b/test/Android/ZumoE2ETestApp/src/com/microsoft/windowsazure/mobileservices/zumoe2etestapp/framework/TestGroup.java
@@ -32,6 +32,9 @@ public abstract class TestGroup {
 	ConcurrentLinkedQueue<TestCase> mTestRunQueue;
 	boolean mNewTestRun;
 	
+	public static final String AllTestsGroupName = "All tests";
+	public static final String AllUnattendedTestsGroupName = AllTestsGroupName + " (unattended)";
+	
 	public TestGroup(String name) {
 		mName = name;
 		mStatus = TestStatus.NotRun;

--- a/test/Android/ZumoE2ETestApp/src/com/microsoft/windowsazure/mobileservices/zumoe2etestapp/framework/Util.java
+++ b/test/Android/ZumoE2ETestApp/src/com/microsoft/windowsazure/mobileservices/zumoe2etestapp/framework/Util.java
@@ -36,9 +36,12 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import com.microsoft.windowsazure.mobileservices.MobileServiceClient;
 import com.microsoft.windowsazure.mobileservices.ServiceFilterResponse;
 
 public class Util {
+
+	public final static String LogTimeFormat = "yyyy-MM-dd HH:mm:ss'.'SSS";
 
 	public static String createComplexRandomString(Random rndGen, int size) {
 		if (rndGen.nextInt(3) > 0) {
@@ -126,17 +129,21 @@ public class Util {
 	}
 
 	public static String dateToString(Date date) {
+		return dateToString(date, "yyyy-MM-dd'T'HH:mm:ss'.'SSS'Z'");
+	}
+	
+	public static String dateToString(Date date, String dateFormatStr) {
 		if (date == null) {
 			return "NULL";
 		}
-		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'.'SSS'Z'", Locale.getDefault());
+		SimpleDateFormat dateFormat = new SimpleDateFormat(dateFormatStr, Locale.getDefault());
 		dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 
 		String formatted = dateFormat.format(date);
 
 		return formatted;
 	}
-
+	
 	public static boolean compare(Object o1, Object o2) {
 		if (o1 == null && o2 == null) {
 			return true;
@@ -147,6 +154,21 @@ public class Util {
 		}
 
 		return o1.equals(o2);
+	}
+	
+	public static TestCase createSeparatorTest(String testName) {
+		return new TestCase(testName) {
+
+			@Override
+			protected void executeTest(MobileServiceClient client,
+					TestExecutionCallback callback) {
+				TestResult testResult = new TestResult();
+				testResult.setTestCase(this);
+				testResult.setStatus(TestStatus.Passed);
+				callback.onTestComplete(this, testResult);
+			}
+			
+		}; 
 	}
 
 	public static boolean compareJson(JsonElement e1, JsonElement e2) {

--- a/test/Android/ZumoE2ETestApp/src/com/microsoft/windowsazure/mobileservices/zumoe2etestapp/tests/CustomApiTests.java
+++ b/test/Android/ZumoE2ETestApp/src/com/microsoft/windowsazure/mobileservices/zumoe2etestapp/tests/CustomApiTests.java
@@ -98,9 +98,13 @@ public class CustomApiTests extends TestGroup {
 				this.addTest(createJsonApiTest(permission, false, rndGen, i));
 			}
 		}
-		
-		this.addTest(LoginTests.createLoginTest(MobileServiceAuthenticationProvider.Facebook));
-		this.addTest(createJsonApiTest(ApiPermissions.User, true, rndGen, 0));
+
+		TestCase loginTest = LoginTests.createLoginTest(MobileServiceAuthenticationProvider.Facebook);
+		loginTest.setCanRunUnattended(false);
+		this.addTest(loginTest);
+		TestCase apiAuthenticatedTest = createJsonApiTest(ApiPermissions.User, true, rndGen, 0);
+		apiAuthenticatedTest.setCanRunUnattended(false);
+		this.addTest(apiAuthenticatedTest);
 		this.addTest(LoginTests.createLogoutTest());
 		
 		for (TypedTestType testType : TypedTestType.values()) {

--- a/test/Android/ZumoE2ETestApp/src/com/microsoft/windowsazure/mobileservices/zumoe2etestapp/tests/LoginTests.java
+++ b/test/Android/ZumoE2ETestApp/src/com/microsoft/windowsazure/mobileservices/zumoe2etestapp/tests/LoginTests.java
@@ -20,6 +20,7 @@ See the Apache Version 2.0 License for specific language governing permissions a
 package com.microsoft.windowsazure.mobileservices.zumoe2etestapp.tests;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import com.google.gson.JsonObject;
@@ -54,6 +55,8 @@ public class LoginTests extends TestGroup {
 		this.addTest(createCRUDTest(USER_PERMISSION_TABLE_NAME, null, TablePermission.User, false));
 		this.addTest(createCRUDTest(ADMIN_PERMISSION_TABLE_NAME, null, TablePermission.Admin, false));
 
+		int indexOfStartAuthenticationTests = this.getTestCases().size();
+		
 		ArrayList<MobileServiceAuthenticationProvider> providersWithRecycledTokenSupport = new ArrayList<MobileServiceAuthenticationProvider>();
 		providersWithRecycledTokenSupport.add(MobileServiceAuthenticationProvider.Facebook);
 		providersWithRecycledTokenSupport.add(MobileServiceAuthenticationProvider.Google);
@@ -70,6 +73,11 @@ public class LoginTests extends TestGroup {
 				this.addTest(createClientSideLoginTest(provider));
 				this.addTest(createCRUDTest(USER_PERMISSION_TABLE_NAME, provider, TablePermission.User, true));
 			}
+		}
+
+		List<TestCase> testCases = this.getTestCases();
+		for (int i = indexOfStartAuthenticationTests; i < testCases.size(); i++) {
+			testCases.get(i).setCanRunUnattended(false);
 		}
 	}
 


### PR DESCRIPTION
This adds the ability to run all tests at once in the Android E2E Test App. It also updates the output of the test logs to be consistent with other platforms, to make it easier to parse into test results.
