### PR TITLE
WinJS/HTML: allow server responses with no content

### DIFF
--- a/sdk/Javascript/src/Utilities/Extensions.js
+++ b/sdk/Javascript/src/Utilities/Extensions.js
@@ -220,27 +220,30 @@ exports.fromJson = function (value) {
     /// <param name="value" type="String">The value to convert.</param>
     /// <returns type="Object">The value as an object.</returns>
 
-    Validate.isString(value, 'value');
-
-    // We're wrapping this so we can hook the process and perform custom JSON
-    // conversions
-    return JSON.parse(
-        value,
-        function (k, v) {
-            // Try to convert the value as a Date
-            if (_.isString(v) && !_.isNullOrEmpty(v)) {
-                var date = exports.tryParseIsoDateString(v);
-                if (!_.isNull(date)) {
-                    return date;
+    var jsonValue = null;
+    if (!_.isNullOrEmpty(value)) {
+        // We're wrapping this so we can hook the process and perform custom JSON
+        // conversions
+        jsonValue = JSON.parse(
+            value,
+            function (k, v) {
+                // Try to convert the value as a Date
+                if (_.isString(v) && !_.isNullOrEmpty(v)) {
+                    var date = exports.tryParseIsoDateString(v);
+                    if (!_.isNull(date)) {
+                        return date;
+                    }
                 }
-            }
 
-            // TODO: Convert geolocations once they're supported
-            // TODO: Expose the ability for developers to convert custom types
-            
-            // Return the original value if we couldn't do anything with it
-            return v;
-        });
+                // TODO: Convert geolocations once they're supported
+                // TODO: Expose the ability for developers to convert custom types
+
+                // Return the original value if we couldn't do anything with it
+                return v;
+            });
+    }
+
+    return jsonValue;
 };
 
 exports.createUniqueInstallationId = function () {

--- a/sdk/Javascript/test/winJS/tests/unit/mobileServiceTables.js
+++ b/sdk/Javascript/test/winJS/tests/unit/mobileServiceTables.js
@@ -108,6 +108,21 @@ $testGroup('MobileServiceTables.js',
         });
     }),
 
+    $test('query via table.read() with no response content')
+    .description('Verify MobileServiceTable table operations allow responses without content')
+    .checkAsync(function () {
+        var client = new WindowsAzure.MobileServiceClient("http://www.test.com", "123456abcdefg");
+        client = client.withFilter(function (req, next, callback) {
+            $assert.areEqual(req.url, 'http://www.test.com/tables/books');
+            callback(null, { status: 200, responseText: "" });
+        });
+
+        var table = client.getTable('books');
+        return table.read().then(function (results) {
+            $assert.areEqual(results, null);
+        });
+    }),
+
     $test('query via table.read() with user-defined parameters')
     .description('Verify MobileServiceTable.read implies a default query even when used with user-defined query string parmeters')
     .checkAsync(function () {


### PR DESCRIPTION
If the server returns no content because the developer used a server-side script that just returns a 200 but no content, the WinJS/HTML client will call JSON.parse on an empty string, which will result in an exception. This small fix just changes the client to return a null results value to the table operation callback instead of throwing the exception.   
