### PR TITLE
Issue #137 - handling of different settings for Option Compare

### DIFF
--- a/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/Table/Query/FilterBuildingExpressionVisitor.cs
+++ b/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/Table/Query/FilterBuildingExpressionVisitor.cs
@@ -665,8 +665,7 @@ namespace Microsoft.WindowsAzure.MobileServices
                         methodCall.Method.Name == VBCompareStringMethod &&
                         methodCall.Arguments.Count == VBCompareStringArguments &&
                         methodCall.Arguments[VBCaseSensitiveCompareArgumentIndex].Type == typeof(bool) &&
-                        methodCall.Arguments[VBCaseSensitiveCompareArgumentIndex].NodeType == ExpressionType.Constant &&
-                        ((ConstantExpression)methodCall.Arguments[VBCaseSensitiveCompareArgumentIndex]).Value.Equals(false))
+                        methodCall.Arguments[VBCaseSensitiveCompareArgumentIndex].NodeType == ExpressionType.Constant)
                     {
                         bool doCaseInsensitiveComparison = ((ConstantExpression)methodCall.Arguments[VBCaseSensitiveCompareArgumentIndex]).Value.Equals(true);
                         Expression leftExpression = methodCall.Arguments[0];
@@ -680,22 +679,22 @@ namespace Microsoft.WindowsAzure.MobileServices
                         switch (expression.NodeType)
                         {
                             case ExpressionType.Equal:
-                                stringComparison = BinaryExpression.Equal(methodCall.Arguments[0], methodCall.Arguments[1]);
+                                stringComparison = BinaryExpression.Equal(leftExpression, rightExpression);
                                 break;
                             case ExpressionType.NotEqual:
-                                stringComparison = BinaryExpression.NotEqual(methodCall.Arguments[0], methodCall.Arguments[1]);
+                                stringComparison = BinaryExpression.NotEqual(leftExpression, rightExpression);
                                 break;
                             case ExpressionType.LessThan:
-                                stringComparison = BinaryExpression.LessThan(methodCall.Arguments[0], methodCall.Arguments[1]);
+                                stringComparison = BinaryExpression.LessThan(leftExpression, rightExpression);
                                 break;
                             case ExpressionType.LessThanOrEqual:
-                                stringComparison = BinaryExpression.LessThanOrEqual(methodCall.Arguments[0], methodCall.Arguments[1]);
+                                stringComparison = BinaryExpression.LessThanOrEqual(leftExpression, rightExpression);
                                 break;
                             case ExpressionType.GreaterThan:
-                                stringComparison = BinaryExpression.GreaterThan(methodCall.Arguments[0], methodCall.Arguments[1]);
+                                stringComparison = BinaryExpression.GreaterThan(leftExpression, rightExpression);
                                 break;
                             case ExpressionType.GreaterThanOrEqual:
-                                stringComparison = BinaryExpression.GreaterThanOrEqual(methodCall.Arguments[0], methodCall.Arguments[1]);
+                                stringComparison = BinaryExpression.GreaterThanOrEqual(leftExpression, rightExpression);
                                 break;
                         }
 

--- a/sdk/Managed/test/Microsoft.WindowsAzure.Mobile.Net45.Vb.Test/Microsoft.WindowsAzure.Mobile.Net45.Vb.Test.vbproj
+++ b/sdk/Managed/test/Microsoft.WindowsAzure.Mobile.Net45.Vb.Test/Microsoft.WindowsAzure.Mobile.Net45.Vb.Test.vbproj
@@ -101,12 +101,14 @@
     <Import Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="TestsForOptionCompareBinary.vb" />
     <Compile Include="QueryTests.vb" />
     <Compile Include="My Project\AssemblyInfo.vb" />
     <Compile Include="My Project\Application.Designer.vb">
       <AutoGen>True</AutoGen>
       <DependentUpon>Application.myapp</DependentUpon>
     </Compile>
+    <Compile Include="TestsForOptionCompareText.vb" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/sdk/Managed/test/Microsoft.WindowsAzure.Mobile.Net45.Vb.Test/QueryTests.vb
+++ b/sdk/Managed/test/Microsoft.WindowsAzure.Mobile.Net45.Vb.Test/QueryTests.vb
@@ -5,7 +5,7 @@ Imports Newtonsoft.Json
 
 <TestClass()> Public Class QueryTests
 
-    Private Function Compile(Of T, U)(ByVal getQuery As Func(Of IMobileServiceTable(Of T), IMobileServiceTableQuery(Of U))) As MobileServiceTableQueryDescription
+    Friend Shared Function Compile(Of T, U)(ByVal getQuery As Func(Of IMobileServiceTable(Of T), IMobileServiceTableQuery(Of U))) As MobileServiceTableQueryDescription
         Dim client = New MobileServiceClient("http://www.test.com")
         Dim table As IMobileServiceTable(Of T) = client.GetTable(Of T)()
         Dim query As IMobileServiceTableQuery(Of U) = getQuery(table)

--- a/sdk/Managed/test/Microsoft.WindowsAzure.Mobile.Net45.Vb.Test/TestsForOptionCompareBinary.vb
+++ b/sdk/Managed/test/Microsoft.WindowsAzure.Mobile.Net45.Vb.Test/TestsForOptionCompareBinary.vb
@@ -1,0 +1,13 @@
+﻿Option Compare Binary
+
+<TestClass> Public Class TestsForOptionCompareBinary
+    <TestMethod> Public Sub StringComparison_OptionCompareBinary()
+        Dim query = QueryTests.Compile(Of Product, Product)(Function(table) _
+                                                                table.Where(Function(x) x.Name = "Zumo"))
+        Assert.AreEqual("(Name eq 'Zumo')", query.Filter)
+
+        query = QueryTests.Compile(Of Product, Product)(Function(table) _
+                                                                        table.Where(Function(x) x.Name <> "Zumo"))
+        Assert.AreEqual("(Name ne 'Zumo')", query.Filter)
+    End Sub
+End Class

--- a/sdk/Managed/test/Microsoft.WindowsAzure.Mobile.Net45.Vb.Test/TestsForOptionCompareText.vb
+++ b/sdk/Managed/test/Microsoft.WindowsAzure.Mobile.Net45.Vb.Test/TestsForOptionCompareText.vb
@@ -1,0 +1,13 @@
+﻿Option Compare Text
+
+<TestClass> Public Class TestsForOptionCompareText
+    <TestMethod> Public Sub StringComparison_OptionCompareText()
+        Dim query = QueryTests.Compile(Of Product, Product)(Function(table) _
+                                                                table.Where(Function(x) x.Name = "Zumo"))
+        Assert.AreEqual("(tolower(Name) eq tolower('Zumo'))", query.Filter)
+
+        query = QueryTests.Compile(Of Product, Product)(Function(table) _
+                                                                        table.Where(Function(x) x.Name <> "Zumo"))
+        Assert.AreEqual("(tolower(Name) ne tolower('Zumo'))", query.Filter)
+    End Sub
+End Class


### PR DESCRIPTION
The code to deal with the different values of `Option Compare` was incorrect in the previous commit; this fixes it.
