### PR TITLE
Removing Alerts for RunAllTestsUnAttended

### DIFF
--- a/test/JavaScript/TestFramework/js/testFrameworkConnections.js
+++ b/test/JavaScript/TestFramework/js/testFrameworkConnections.js
@@ -68,17 +68,26 @@ document.getElementById('btnRunTests').onclick = function (evt) {
         saveLastUsedAppInfo();
 
         var groupDone = function (testsPassed, testsFailed) {
+            var logs = 'Test group finished';
+            logs = logs + '\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n';
+            logs = logs + 'Tests passed: ' + testsPassed + '\n';
+            logs = logs + 'Tests failed: ' + testsFailed;
             if (currentGroup.name.indexOf(zumo.AllTestsGroupName) === 0 && uploadUrl !== '') {
                 // For all tests, upload logs automatically if URL is set
                 var testLogs = currentGroup.getLogs();
                 uploadLogs(uploadUrl, testLogs, true);
-            } else {
-                var logs = 'Test group finished';
-                logs = logs + '\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n';
-                logs = logs + 'Tests passed: ' + testsPassed + '\n';
-                logs = logs + 'Tests failed: ' + testsFailed;
+                if (testsFailed == 0) {
+                    btnRunAllUnattendedTests.textContent = "Passed";
+                }
+                else {
+                    btnRunAllUnattendedTests.textContent = "Failed";
+                }
+            }
+
+            if (showAlerts) {
                 testPlatform.alert(logs);
             }
+
         }
         var updateTest = function (test, index) {
             var tblTests = document.getElementById('tblTestsBody');
@@ -134,7 +143,9 @@ function uploadLogs(url, logs, allTests, done) {
     var xhr = new XMLHttpRequest();
     xhr.onreadystatechange = function () {
         if (xhr.readyState === 4) {
-            testPlatform.alert(xhr.responseText);
+            if (showAlerts) {
+                testPlatform.alert(xhr.responseText);
+            }
             if (done) {
                 done();
             }
@@ -166,6 +177,7 @@ var testGroups = zumo.testGroups;
 
 var btnRunAllTests = document.getElementById('btnRunAllTests');
 var btnRunAllUnattendedTests = document.getElementById('btnRunAllUnattendedTests');
+var showAlerts = true;
 
 if (btnRunAllTests) btnRunAllTests.onclick = handlerForAllTestsButtons(false);
 if (btnRunAllUnattendedTests) btnRunAllUnattendedTests.onclick = handlerForAllTestsButtons(true);
@@ -223,6 +235,7 @@ function testGroupSelected(index) {
     });
 
     if (group.name === zumo.AllTestsGroupName || group.name === zumo.AllTestsUnattendedGroupName) {
+        showAlerts = false;
         document.getElementById('btnRunTests').click();
     }
 }


### PR DESCRIPTION
Removing Alerts for RunAllTestsUnAttended and changing text in the button to indicate tests passed or failed
