### PR TITLE
Comment out case: Login via Google Token

### DIFF
--- a/test/Android/ZumoE2ETestApp/src/com/microsoft/windowsazure/mobileservices/zumoe2etestapp/tests/LoginTests.java
+++ b/test/Android/ZumoE2ETestApp/src/com/microsoft/windowsazure/mobileservices/zumoe2etestapp/tests/LoginTests.java
@@ -61,7 +61,8 @@ public class LoginTests extends TestGroup {
 		
 		ArrayList<MobileServiceAuthenticationProvider> providersWithRecycledTokenSupport = new ArrayList<MobileServiceAuthenticationProvider>();
 		providersWithRecycledTokenSupport.add(MobileServiceAuthenticationProvider.Facebook);
-		providersWithRecycledTokenSupport.add(MobileServiceAuthenticationProvider.Google);
+		// Known bug - Drop login via Google token until Google client flow is reintroduced
+		//providersWithRecycledTokenSupport.add(MobileServiceAuthenticationProvider.Google);
 
 		for (MobileServiceAuthenticationProvider provider : MobileServiceAuthenticationProvider.values()) {
 			this.addTest(createLogoutTest());

--- a/test/JavaScript/TestFramework/js/tests/loginTests.js
+++ b/test/JavaScript/TestFramework/js/tests/loginTests.js
@@ -26,7 +26,7 @@ function defineLoginTestsNamespace() {
 
     var supportRecycledToken = {
         facebook: true,
-        google: true,
+        google: false, // Known bug - Drop login via Google token until Google client flow is reintroduced
         twitter: false,
         microsoftaccount: false
     };

--- a/test/PLib/ZumoE2ETestApp/ZumoE2ETestApp/Tests/ZumoLoginTests.cs
+++ b/test/PLib/ZumoE2ETestApp/ZumoE2ETestApp/Tests/ZumoLoginTests.cs
@@ -42,7 +42,7 @@ namespace ZumoE2ETestApp.Tests
             providersWithRecycledTokenSupport = new Dictionary<MobileServiceAuthenticationProvider, bool>
             {
                 { MobileServiceAuthenticationProvider.Facebook, true },
-                { MobileServiceAuthenticationProvider.Google, true },
+                { MobileServiceAuthenticationProvider.Google, false },   // Known bug - Drop login via Google token until Google client flow is reintroduced
                 { MobileServiceAuthenticationProvider.MicrosoftAccount, false },
                 { MobileServiceAuthenticationProvider.Twitter, false },
             };

--- a/test/iOS/ZumoE2ETestApp/ZumoE2ETestApp/ZumoLoginTests.m
+++ b/test/iOS/ZumoE2ETestApp/ZumoE2ETestApp/ZumoLoginTests.m
@@ -53,7 +53,7 @@ NSDictionary *lastUserIdentityObject;
     int indexOfLastUnattendedTest = [result count];
     
     NSArray *providers = @[@"facebook", @"google", @"twitter", @"microsoftaccount"];
-    NSArray *providersWithRecycledTokenSupport = @[@"facebook", @"google"];
+    NSArray *providersWithRecycledTokenSupport = @[@"facebook"]; //, @"google"]; Known bug - Drop login via Google token until Google client flow is reintroduced
     NSString *provider;
     
     for (int useSimplifiedLogin = 0; useSimplifiedLogin <= 1; useSimplifiedLogin++) {


### PR DESCRIPTION
Drop login tests via Google token until Google client flow is reintroduced.
