### PR TITLE
Android quickstart fixes

### DIFF
--- a/quickstart/android/ZUMOAPPNAME/project.properties
+++ b/quickstart/android/ZUMOAPPNAME/project.properties
@@ -11,4 +11,4 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-17
+target=android-18

--- a/quickstart/android/ZUMOAPPNAME/src/com/example/zumoappname/ToDoActivity.java
+++ b/quickstart/android/ZUMOAPPNAME/src/com/example/zumoappname/ToDoActivity.java
@@ -210,7 +210,11 @@ public class ToDoActivity extends Activity {
 	 *            The dialog title
 	 */
 	private void createAndShowDialog(Exception exception, String title) {
-		createAndShowDialog(exception.toString(), title);
+		Throwable ex = exception;
+		if(exception.getCause() != null){
+			ex = exception.getCause();
+		}
+		createAndShowDialog(ex.getMessage(), title);
 	}
 
 	/**


### PR DESCRIPTION
- Updated the Android target to prevent an upgrade being triggered when the quickstart is opened in the latest tools
- Updated exception handling logic so it would show the best possible information. In some cases we want the message of the parent exception. In other cases the useful information is actually in the message of the child exception.
