### PR TITLE
Check response getResponseHeader on IE9

### DIFF
--- a/test/JavaScript/TestFramework/js/tests/miscTests.js
+++ b/test/JavaScript/TestFramework/js/tests/miscTests.js
@@ -45,7 +45,7 @@ function defineMiscTestsNamespace() {
             next(request, function (error, response) {
                 filter.error = error;
                 filter.response = response;
-                if (!error && response) {
+                if (!error && response && response.getResponseHeader) { // IE9 not support response.getResponseHeader
                     var serverVersion = response.getResponseHeader('x-zumo-version');
                     if (serverVersion) {
                         zumo.util.globalTestParams[zumo.constants.SERVER_VERSION_KEY] = serverVersion;


### PR DESCRIPTION
Add check for response getResponseHeader when using IE9 
