### PR TITLE
Add arm64.

### DIFF
--- a/sdk/iOS/WindowsAzureMobileServices.xcodeproj/project.pbxproj
+++ b/sdk/iOS/WindowsAzureMobileServices.xcodeproj/project.pbxproj
@@ -703,6 +703,7 @@
 		E8F33B011616659C002DD7C6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
@@ -722,6 +723,7 @@
 		E8F33B021616659C002DD7C6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;


### PR DESCRIPTION
New iPhone models with the A7 chip support Arm64.  It is important that apps support this architecture to avoid loading the 32bit frameworks.  

https://developer.apple.com/library/ios/documentation/General/Conceptual/CocoaTouch64BitGuide/Introduction/Introduction.html

This change simply adds arm64 as a valid architecture for the iOS SDK.  It builds without warnings.
