### PR TITLE
Add support for the Azure Active Directory authentication provider

### DIFF
--- a/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/Authentication/MobileServiceAuthentication.cs
+++ b/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/Authentication/MobileServiceAuthentication.cs
@@ -31,6 +31,17 @@ namespace Microsoft.WindowsAzure.MobileServices
         protected const string LoginAsyncDoneUriFragment = "login/done";
 
         /// <summary>
+        /// Name of the authentication provider as expected by the service REST API.
+        /// </summary>
+        private string providerName;
+
+        /// <summary>
+        /// The name for the Azure Active Directory authentication provider as used by the
+        /// service REST API.
+        /// </summary>
+        internal const string WindowsAzureActiveDirectoryRestApiPathName = "aad";
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="MobileServiceAuthentication"/> class.
         /// </summary>
         /// <param name="client">
@@ -50,9 +61,9 @@ namespace Microsoft.WindowsAzure.MobileServices
 
             this.Client = client;
 
-            this.ProviderName = providerName.ToLower();
+            this.ProviderName = providerName;
 
-            this.StartUri = new Uri(this.Client.ApplicationUri, MobileServiceAuthentication.LoginAsyncUriFragment + "/" + providerName);
+            this.StartUri = new Uri(this.Client.ApplicationUri, MobileServiceAuthentication.LoginAsyncUriFragment + "/" + this.ProviderName);
             this.EndUri = new Uri(this.Client.ApplicationUri, MobileServiceAuthentication.LoginAsyncDoneUriFragment);
         }
 
@@ -66,7 +77,18 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// The name of the authentication provider used by this
         /// <see cref="MobileServiceAuthentication"/> instance.
         /// </summary>
-        protected string ProviderName { get; private set; }
+        protected string ProviderName
+        {
+            get { return this.providerName; }
+            private set
+            {
+                this.providerName = value.ToLowerInvariant();
+                if (this.providerName.Equals(MobileServiceAuthenticationProvider.WindowsAzureActiveDirectory.ToString(), StringComparison.OrdinalIgnoreCase))
+                {
+                    this.providerName = WindowsAzureActiveDirectoryRestApiPathName;
+                }
+            }
+        }
 
         /// <summary>
         /// The start uri to use for authentication.

--- a/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/Authentication/MobileServiceAuthenticationProvider.cs
+++ b/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/Authentication/MobileServiceAuthenticationProvider.cs
@@ -27,6 +27,11 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// <summary>
         /// Facebook authentication provider.
         /// </summary>
-        Facebook
+        Facebook,
+
+        /// <summary>
+        /// Azure Active Directory authentication provider.
+        /// </summary>
+        WindowsAzureActiveDirectory,
     }
 }

--- a/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/MobileServiceClient.cs
+++ b/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/MobileServiceClient.cs
@@ -323,11 +323,6 @@ namespace Microsoft.WindowsAzure.MobileServices
                 throw new ArgumentNullException("token");
             }
 
-            if (!Enum.IsDefined(typeof(MobileServiceAuthenticationProvider), provider))
-            {
-                throw new ArgumentOutOfRangeException("provider");
-            }
-
             MobileServiceTokenAuthentication auth = new MobileServiceTokenAuthentication(this, provider, token);
             return auth.LoginAsync();
         }

--- a/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.WindowsPhone8.Test/MainPage.xaml
+++ b/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.WindowsPhone8.Test/MainPage.xaml
@@ -81,6 +81,9 @@
                 <Button x:Name="GoogleButton"
                         Content="Google" 
                         Click="LoginButtonClicked"/>
+                <Button x:Name="AzureActiveDirectoryButton"
+                        Content="Windows Azure Active Directory" 
+                        Click="LoginButtonClicked"/>
                 <CheckBox x:Name="UseProviderStringOverloadCheckBox"
                           Content="Use overload with string provider"
                           IsChecked="false"/>

--- a/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.WindowsPhone8.Test/MainPage.xaml.cs
+++ b/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.WindowsPhone8.Test/MainPage.xaml.cs
@@ -80,6 +80,11 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
                     provider = MobileServiceAuthenticationProvider.Google;
                     testName = "Google Login";
                 }
+                else if (buttonClicked.Name.Contains("AzureActiveDirectory"))
+                {
+                    provider = MobileServiceAuthenticationProvider.WindowsAzureActiveDirectory;
+                    testName = "Azure Active Directory Login";
+                }
 
                 bool useProviderStringOverload = UseProviderStringOverloadCheckBox.IsChecked.Value;
 

--- a/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.WindowsStore.Test/UI/LoginPage.xaml
+++ b/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.WindowsStore.Test/UI/LoginPage.xaml
@@ -66,6 +66,7 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
                     <Button
@@ -96,20 +97,27 @@
                         Content="Google" 
                         Style="{StaticResource ButtonStyleRight}"
                         Click="LoginButtonClicked"/>
-                    <CheckBox
+                    <Button
                         Grid.Row="2"
+                        Grid.Column="0"
+                        x:Name="AzureActiveDirectoryButton"
+                        Content="Azure Active Directory"
+                        Style="{StaticResource ButtonStyleLeft}"
+                        Click="LoginButtonClicked"/>
+                    <CheckBox
+                        Grid.Row="3"
                         Grid.Column="0"
                         x:Name="UseSingleSignOnCheckBox"
                         Content="Use Single Sign-On"
                         IsChecked="true" Margin="0,10"/>
                     <CheckBox
-                        Grid.Row="2"
+                        Grid.Row="3"
                         Grid.Column="1"
                         x:Name="UseStringProviderOverloadCheckBox"
                         Content="Use overload with string provider"
                         IsChecked="False" Margin="0,10"/>
                     <TextBlock 
-                        Grid.Row="3"
+                        Grid.Row="4"
                         Grid.Column="0"
                         Grid.ColumnSpan="2"
             	        HorizontalAlignment="Left" 
@@ -121,7 +129,7 @@
                         FontSize="15">
                     </TextBlock>
                     <TextBlock
-                        Grid.Row="4"
+                        Grid.Row="5"
                         Grid.Column="0"
                         Grid.ColumnSpan="2"
                         x:Name="TestResultsTextBlock"

--- a/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.WindowsStore.Test/UI/LoginPage.xaml.cs
+++ b/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.WindowsStore.Test/UI/LoginPage.xaml.cs
@@ -44,6 +44,11 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
                     provider = MobileServiceAuthenticationProvider.Google;
                     testName = "Google Login";
                 }
+                else if (buttonClicked.Name.Contains("AzureActiveDirectory"))
+                {
+                    provider = MobileServiceAuthenticationProvider.WindowsAzureActiveDirectory;
+                    testName = "Azure Active Directory Login";
+                }
 
                 bool useSingleSignOn = UseSingleSignOnCheckBox.IsChecked.Value;
                 bool useStringProviderOverload = UseStringProviderOverloadCheckBox.IsChecked.Value;


### PR DESCRIPTION
- Adding support for WAAD on the managed SDK
- Also removed the restriction to the `LoginAsync` call to only allow strings defined in the enumeration, to allow for (future) extensibility.
