### PR TITLE
Fix #207: using com.google.gson types in typed custom API calls

### DIFF
--- a/sdk/android/src/sdk/src/com/microsoft/windowsazure/mobileservices/MobileServiceClient.java
+++ b/sdk/android/src/sdk/src/com/microsoft/windowsazure/mobileservices/MobileServiceClient.java
@@ -596,7 +596,11 @@ public class MobileServiceClient {
 				
 		JsonElement json = null;
 		if (body != null) {
-			json = getGsonBuilder().create().toJsonTree(body);
+			if (body instanceof JsonElement) {
+				json = (JsonElement)body;
+			} else {
+				json = getGsonBuilder().create().toJsonTree(body);
+			}
 		}
 		
 		invokeApi(apiName, json, httpMethod, parameters, new ApiJsonOperationCallback() {


### PR DESCRIPTION
When invoking typed APIs, if the body is a `JsonElement` / `JsonObject` / `JsonArray` / `JsonPrimitive` / `JsonNull` then use the value "as-is" instead of trying to serialize it.
