### PR TITLE
Fixed insert empty task in iOS-swift app

### DIFF
--- a/quickstart/iOS-Swift/ZUMOAPPNAME/ZUMOAPPNAME/ToDoTableViewController.swift
+++ b/quickstart/iOS-Swift/ZUMOAPPNAME/ZUMOAPPNAME/ToDoTableViewController.swift
@@ -138,7 +138,9 @@ class ToDoTableViewController: UITableViewController, ToDoItemDelegate {
     
     func didSaveItem(text: String)
     {
-        if (text == "") { return; }
+        if text.isEmpty {
+            return
+        }
         
         let itemToInsert = ["text": text, "complete": false]
         


### PR DESCRIPTION
iOS-Swift app can insert empty string task.
I fixed it.
