### PR TITLE
Update json serializer so object gets replaced

### DIFF
--- a/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/Table/Serialization/MobileServiceJsonSerializerSettings.cs
+++ b/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/Table/Serialization/MobileServiceJsonSerializerSettings.cs
@@ -22,6 +22,7 @@ namespace Microsoft.WindowsAzure.MobileServices
         {
             this.NullValueHandling = NullValueHandling.Include;
             this.ContractResolver = new MobileServiceContractResolver();
+            this.ObjectCreationHandling = ObjectCreationHandling.Replace;
 
             this.Converters.Add(new MobileServiceIsoDateTimeConverter());
             this.Converters.Add(new MobileServicePrecisionCheckConverter());

--- a/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.Test/FunctionalTests/Table/MobileServiceTableTest.cs
+++ b/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.Test/FunctionalTests/Table/MobileServiceTableTest.cs
@@ -55,6 +55,15 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
         public String Version { get; set; }
     }
 
+    public class TypeWithArray
+    {
+        public string Id { get; set; }
+
+        [JsonProperty("values")]
+        public List<string> Values { get; set; }
+
+    }
+
     [Tag("e2e")]
     [Tag("table")]
     public class MobileServiceTableGenericFunctionalTests : FunctionalTestBase

--- a/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.Test/UnitTests/Table/MobileServiceTable.Generic.Test.cs
+++ b/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.Test/UnitTests/Table/MobileServiceTable.Generic.Test.cs
@@ -1622,6 +1622,30 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
         }
 
         [AsyncTestMethod]
+        public async Task InsertAsyncWithStringIdAndList_DoesNotDuplicateList()
+        {
+            TestHttpHandler hijack = new TestHttpHandler();
+            hijack.SetResponseContent("{\"id\":\"an id\",\"Values\":[\"goodbye\",\"universe\"]}");
+            IMobileServiceClient service = new MobileServiceClient("http://www.test.com", "secret...", hijack);
+
+            IMobileServiceTable<TypeWithArray> table = service.GetTable<TypeWithArray>();
+            var item = new TypeWithArray()
+            {
+                Id = "an id",
+                Values = new List<string> {
+                    "hello", "world"
+                }
+            };
+
+            await table.InsertAsync(item);
+
+            Assert.AreEqual("an id", item.Id);
+            Assert.AreEqual(item.Values.Count, 2);
+            Assert.AreEqual(item.Values[0], "goodbye");
+            Assert.AreEqual(item.Values[1], "universe");
+        }
+
+        [AsyncTestMethod]
         public async Task InsertAsyncWithIntIdTypeAndIntIdResponseContent()
         {
             long[] testIdData = IdTestData.ValidIntIds.Concat(


### PR DESCRIPTION
Fix issue with arrays coming back getting appended to existing array in item when using a generic.  

As an example, if item had a property that was an array with values a,b then after calling update/insert/refresh, item would now have the values a,b,a,b.  With this fix, the server copy will replace the client copy of the array (an not append it)
