### PR TITLE
Correct visibility of Push on Xamarin iOS

### DIFF
--- a/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices.iOS/Extensions/MobileServiceClientExtensions.cs
+++ b/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices.iOS/Extensions/MobileServiceClientExtensions.cs
@@ -155,7 +155,7 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// <returns>
         /// The <see cref="Push"/> object used for registering for notifications.
         /// </returns>
-        internal static Push GetPush(this MobileServiceClient client)
+        public static Push GetPush(this MobileServiceClient client)
         {
             return new Push(client);
         }

--- a/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices.iOS/Push/ApnsRegistration.cs
+++ b/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices.iOS/Push/ApnsRegistration.cs
@@ -12,7 +12,7 @@ namespace Microsoft.WindowsAzure.MobileServices
     /// Registration is used to define a target that is registered for notifications
     /// </summary>
     [JsonObject(MemberSerialization.OptIn)]
-    internal class ApnsRegistration : Registration
+    public class ApnsRegistration : Registration
     {
         internal ApnsRegistration()
         {

--- a/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices.iOS/Push/ApnsTemplateRegistration.cs
+++ b/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices.iOS/Push/ApnsTemplateRegistration.cs
@@ -16,7 +16,7 @@ namespace Microsoft.WindowsAzure.MobileServices
     /// to define the format of the registration.
     /// </summary>
     [JsonObject(MemberSerialization.OptIn)]
-    internal sealed class ApnsTemplateRegistration : ApnsRegistration
+    public sealed class ApnsTemplateRegistration : ApnsRegistration
     {
         internal ApnsTemplateRegistration()
         {

--- a/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices.iOS/Push/Push.cs
+++ b/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices.iOS/Push/Push.cs
@@ -13,7 +13,7 @@ namespace Microsoft.WindowsAzure.MobileServices
     /// <summary>
     /// Define a class help to create/update/delete notification registrations
     /// </summary>
-    internal sealed class Push
+    public sealed class Push
     {
         internal readonly RegistrationManager RegistrationManager;
 


### PR DESCRIPTION
We published when unit and functional tests worked. Because we have no app without InternalsVisibleTo using this code, we missed that visibility was still internal.
