### PR TITLE
Fixed duplicate symbols by inclusion of .m file

### DIFF
--- a/sdk/iOS/src/MSSyncContext.m
+++ b/sdk/iOS/src/MSSyncContext.m
@@ -7,7 +7,8 @@
 #import "MSClientInternal.h"
 #import "MSTable.h"
 #import "MSTableOperationInternal.h"
-#import "MSTableOperationError.m"
+#import "MSTableOperationError.h"
+#import "MSJSONSerializer.h"
 #import "MSQuery.h"
 #import "MSQueuePushOperation.h"
 


### PR DESCRIPTION
Changed inclusion of MSTableOperationError.m to MSTableOperationError.h to avoid duplicate symbols. Inclusion of the .m file was causing duplication definition of MSTableOperationError in my project by inclusion of the implementation twice in compilation.
