### PR TITLE
[IOS] Adjust tests for 64, update prev merge

### DIFF
--- a/sdk/iOS/src/MSClientConnection.m
+++ b/sdk/iOS/src/MSClientConnection.m
@@ -158,21 +158,25 @@ static NSOperationQueue *delegateQueue;
                completion:(MSFilterResponseBlock)completion
 {
     if (!filters || filters.count == 0) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-        
-        // No filters to invoke so use |NSURLConnection | to actually
-        // send the request.
-        MSConnectionDelegate *delegate = [[MSConnectionDelegate alloc]
-                                          initWithClient:client
-                                              completion:completion];
-        
         if (client.connectionDelegateQueue) {
+            MSConnectionDelegate *delegate = [[MSConnectionDelegate alloc]
+                                              initWithClient:client
+                                              completion:completion];
             NSURLConnection *connection = [[NSURLConnection alloc] initWithRequest:request delegate:delegate startImmediately:NO];
             [connection setDelegateQueue:client.connectionDelegateQueue];
             [connection start];
         } else {
-            [NSURLConnection connectionWithRequest:request delegate:delegate];
-        }});
+            dispatch_async(dispatch_get_main_queue(), ^{
+        
+                // No filters to invoke so use |NSURLConnection | to actually
+                // send the request.
+                MSConnectionDelegate *delegate = [[MSConnectionDelegate alloc]
+                                                  initWithClient:client
+                                                      completion:completion];
+        
+                [NSURLConnection connectionWithRequest:request delegate:delegate];
+            });
+        }
     }
     else {
         

--- a/sdk/iOS/test/MSCoreDataStoreTests.m
+++ b/sdk/iOS/test/MSCoreDataStoreTests.m
@@ -200,7 +200,7 @@
     [self.store upsertItems:testArray table:@"NoSuchTable" orError:&error];
 
     STAssertNotNil(error, @"upsert failed: %@", error.description);
-    STAssertEquals(error.code, MSSyncTableLocalStoreError, @"Unexpected code");
+    STAssertTrue(error.code == MSSyncTableLocalStoreError, @"Unexpected code: %d", error.code);
 }
 
 -(void)testReadWithQuery
@@ -327,7 +327,7 @@
     STAssertNotNil([item objectForKey:@"text"], @"Expected text");
     STAssertNotNil([item objectForKey:@"__meaningOfLife"], @"Expected __meaningOfLine");
     STAssertNotNil([item objectForKey:MSSystemColumnVersion], @"Expected __version");
-    STAssertEquals(item.count, 3U, @"Select returned extra columns");
+    STAssertTrue(item.count == 3U, @"Select returned extra columns");
 }
 
 -(void)testReadWithQuery_NoTable_Error
@@ -341,7 +341,7 @@
 
     STAssertNil(result, @"Result should have been nil");
     STAssertNotNil(error, @"upsert failed: %@", error.description);
-    STAssertEquals(error.code, MSSyncTableLocalStoreError, @"Unexpected code");
+    STAssertTrue(error.code == MSSyncTableLocalStoreError, @"Unexpected code: %d", error.code);
 }
 
 -(void)testDeleteWithId_Success
@@ -391,7 +391,7 @@
     [self.store deleteItemsWithIds:[NSArray arrayWithObject:@"B"] table:@"NoSuchTable" orError:&error];
     
     STAssertNotNil(error, @"upsert failed: %@", error.description);
-    STAssertEquals(error.code, MSSyncTableLocalStoreError, @"Unexpected code");
+    STAssertTrue(error.code == MSSyncTableLocalStoreError, @"Unexpected code %d", error.code);
 }
 
 - (void)testDeleteWithQuery_AllRecord_Success
@@ -445,7 +445,19 @@
     [self.store deleteUsingQuery:query orError:&error];
 
     STAssertNotNil(error, @"upsert failed: %@", error.description);
-    STAssertEquals(error.code, MSSyncTableLocalStoreError, @"Unexpected code");
+    STAssertTrue(error.code == MSSyncTableLocalStoreError, @"Unexpected code: %d", error.code);
+}
+
+-(void)testSystemProperties
+{
+    MSSystemProperties properties = [self.store systemPropetiesForTable:@"ManySystemColumns"];
+    STAssertEquals(properties, MSSystemPropertyCreatedAt | MSSystemPropertyUpdatedAt | MSSystemPropertyVersion | MSSystemPropertyDeleted, nil);
+
+    properties = [self.store systemPropetiesForTable:@"TodoItem"];
+    STAssertEquals(properties, MSSystemPropertyVersion, nil);
+
+    properties = [self.store systemPropetiesForTable:@"TodoItemNoVersion"];
+    STAssertEquals(properties, MSSystemPropertyNone, nil);
 }
 
 - (void) populateTestData

--- a/sdk/iOS/test/MSSyncTableTests.m
+++ b/sdk/iOS/test/MSSyncTableTests.m
@@ -456,8 +456,8 @@
     
     [todoTable pullWithQuery:query completion:^(NSError *error) {
         STAssertNil(error, error.description);
-        STAssertEquals(offline.upsertCalls, 1, @"Unexpected number of upsert calls");
-        STAssertEquals(offline.upsertedItems, 2, @"Unexpected number of upsert calls");
+        STAssertEquals((int)offline.upsertCalls, 1, @"Unexpected number of upsert calls: %d");
+        STAssertEquals((int)offline.upsertedItems, 2, @"Unexpected number of upsert calls: %d");
         done = YES;
     }];
     
@@ -487,8 +487,8 @@
     
     [todoTable pullWithQuery:query completion:^(NSError *error) {
         STAssertNil(error, error.description);
-        STAssertEquals(offline.upsertCalls, 1, @"Unexpected number of upsert calls");
-        STAssertEquals(offline.upsertedItems, 2, @"Unexpected number of upsert calls");
+        STAssertEquals((int)offline.upsertCalls, 1, @"Unexpected number of upsert calls");
+        STAssertEquals((int)offline.upsertedItems, 2, @"Unexpected number of upsert calls");
         done = YES;
     }];
     
@@ -517,10 +517,10 @@
     
     [todoTable pullWithQuery:query completion:^(NSError *error) {
         STAssertNil(error, error.description);
-        STAssertEquals(offline.upsertCalls, 1, @"Unexpected number of upsert calls");
-        STAssertEquals(offline.upsertedItems, 2, @"Unexpected number of upsert calls");
-        STAssertEquals(offline.deleteCalls, 1, @"Unexpected number of delete calls");
-        STAssertEquals(offline.deletedItems, 1, @"Unexpected number of upsert calls");
+        STAssertEquals((int)offline.upsertCalls, 1, @"Unexpected number of upsert calls");
+        STAssertEquals((int)offline.upsertedItems, 2, @"Unexpected number of upsert calls");
+        STAssertEquals((int)offline.deleteCalls, 1, @"Unexpected number of delete calls");
+        STAssertEquals((int)offline.deletedItems, 1, @"Unexpected number of upsert calls");
         done = YES;
     }];
     
@@ -566,8 +566,8 @@
     
     [todoTable pullWithQuery:query completion:^(NSError *error) {
         STAssertNil(error, error.description);
-        STAssertEquals(offline.upsertCalls, 4, @"Unexpected number of upsert calls");
-        STAssertEquals(offline.upsertedItems, 5, @"Unexpected number of upsert calls");
+        STAssertEquals((int)offline.upsertCalls, 4, @"Unexpected number of upsert calls");
+        STAssertEquals((int)offline.upsertedItems, 5, @"Unexpected number of upsert calls");
         
         done = YES;
     }];

--- a/sdk/iOS/test/MSTableFuncTests.m
+++ b/sdk/iOS/test/MSTableFuncTests.m
@@ -30,9 +30,6 @@
     MSClient *client = [MSClient
               clientWithApplicationURLString:@"<Microsoft Azure Mobile Service App URL>"
               applicationKey:@"<Application Key>"];
-    client = [MSClient clientWithApplicationURLString:@"https://philtotesting.azure-mobile.net/"
-                                       applicationKey:@"cusnemNWxPUJEBPdESCAZyZGJqIDUv47"];
-
     
     STAssertTrue([client.applicationURL.description hasPrefix:@"https://"], @"The functional tests are currently disabled.");
     [self continueAfterFailure];
@@ -940,7 +937,7 @@
 {
     NSDate *timeoutAt = [NSDate dateWithTimeIntervalSinceNow:testDuration];
     while (!self.done) {
-        [[NSRunLoop currentRunLoop] runMode:NSRunLoopCommonModes
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
                                  beforeDate:timeoutAt];
         if([timeoutAt timeIntervalSinceNow] <= 0.0) {
             break;

--- a/sdk/iOS/test/MSTableOperationTests.m
+++ b/sdk/iOS/test/MSTableOperationTests.m
@@ -44,7 +44,7 @@
     NSDictionary *info = [originalTableOperation serialize];
     MSTableOperation *tableOperation = [[MSTableOperation alloc] initWithItem:info];
     
-    STAssertEquals(tableOperation.operationId, 7, @"Incorrect id");
+    STAssertEquals((int)tableOperation.operationId, 7, @"Incorrect id");
     STAssertEquals(tableOperation.tableName, @"testTable", @"Incorrect table name");
     STAssertEquals(tableOperation.itemId, @"ABC", @"Incorrect table name");
     STAssertEquals(tableOperation.type, MSTableOperationInsert, @"incorrect type");


### PR DESCRIPTION
Adjust offline related tests to pass on 64 bit devices
Fix bug with functional table tests using wrong run loop
Add missing tests for getting system properties on core data table
