### PR TITLE
Fix issues with Sqlite sync __settings table

### DIFF
--- a/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/Table/Sync/MobileServiceSyncSettingsManager.cs
+++ b/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/Table/Sync/MobileServiceSyncSettingsManager.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.WindowsAzure.MobileServices.Sync;
 using Microsoft.WindowsAzure.MobileServices.Threading;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.WindowsAzure.MobileServices.Sync
@@ -45,7 +46,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Sync
             return this.store.DeleteAsync(MobileServiceLocalSystemTables.Config, GetDeltaTokenKey(tableName, queryKey));
         }        
 
-        public virtual Task<DateTime> GetDeltaToken(string tableName, string queryKey)
+        public virtual Task<DateTime>  GetDeltaToken(string tableName, string queryKey)
         {
             return this.GetSetting(GetDeltaTokenKey(tableName, queryKey), DateTime.MinValue);
         }
@@ -73,7 +74,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Sync
             await this.store.UpsertAsync(MobileServiceLocalSystemTables.Config, new JObject()
             {
                 { MobileServiceSystemColumns.Id, key },
-                { "value", value == null ? null : (string)Convert.ChangeType(value, typeof(string)) }
+                { "value", JsonConvert.SerializeObject(value) }
             }, fromServer: false);
 
             this.cache[key] = value;
@@ -94,7 +95,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Sync
                     else
                     {
                         string rawValue = setting.Value<string>("value");
-                        value = rawValue == null ? defaultValue : Convert.ChangeType(rawValue, typeof(T));
+                        value = JsonConvert.DeserializeObject<T>(rawValue);
                     }
                     this.cache[key] = value;
                 }


### PR DESCRIPTION
This pull-request fixes two issues I encountered with the sqlite sync:
- SetSetting did not update the local in-memory cache. Subsequent syncs would then use out-of-date data and re-fetch unnecessary records.
  The fix is to update the in-memory cache whenever SetSettng is invoked.
- DateTime values stored in the Sync table were not serialized in a round-trippable manner. Because timezone information was stripped and the values were always later interpreted as being UTC the delta value used for subsequent incremental syncs would be incorrect.
  The fix is to use JSON.Net to serialize all values going into the __settings table, which correctly round-trips DateTime values. This has the added benefit of increasing the accuracy of serialized DateTime values.
