### PR TITLE
Adjusted UpsertAsyncInternal to batch inserts

### DIFF
--- a/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices.SQLiteStore/Properties/Resources.Designer.cs
+++ b/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices.SQLiteStore/Properties/Resources.Designer.cs
@@ -134,6 +134,15 @@ namespace Microsoft.WindowsAzure.MobileServices.SQLiteStore.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The number of fields per entity in an upsert operation is limited to {0}..
+        /// </summary>
+        internal static string SQLiteStore_TooManyColumns {
+            get {
+                return ResourceManager.GetString("SQLiteStore_TooManyColumns", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Value of type &apos;{0}&apos; is not supported..
         /// </summary>
         internal static string SQLiteStore_ValueTypeNotSupported {

--- a/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices.SQLiteStore/Properties/Resources.resx
+++ b/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices.SQLiteStore/Properties/Resources.resx
@@ -141,6 +141,9 @@
   <data name="SQLiteStore_TableNotDefined" xml:space="preserve">
     <value>Table with name '{0}' is not defined.</value>
   </data>
+  <data name="SQLiteStore_TooManyColumns" xml:space="preserve">
+    <value>The number of fields per entity in an upsert operation is limited to {0}.</value>
+  </data>
   <data name="SQLiteStore_ValueTypeNotSupported" xml:space="preserve">
     <value>Value of type '{0}' is not supported.</value>
   </data>


### PR DESCRIPTION
I encountered an issue with inserting large numbers of entities during a sync, where the generated SQL insert query exceeded sqlite's limit on bound parameters in prepared statements.

Bulk inserts are now done in batches of 200 bound parameters, e.g.
when inserting collection of records with 10 fields each, each
batch size will be 20 records.

The number 200 is arbitrary.
