### PR TITLE
[iOS Test] Fix copy issue on unattended test path

### DIFF
--- a/test/iOS/ZumoE2ETestApp/ZumoE2ETestApp/ZumoPushTests.m
+++ b/test/iOS/ZumoE2ETestApp/ZumoE2ETestApp/ZumoPushTests.m
@@ -253,8 +253,7 @@ static NSString *pushClientKey = @"PushClientKey";
         } else {
             MSClient *client = [[ZumoTestGlobals sharedInstance] client];
             if ([ZumoPushTests isNhEnabled]) {
-                NSData *deviceToken = [ZumoTestGlobals sharedInstance].deviceToken;
-                [client.push registerNativeWithDeviceToken:deviceToken tags:@[deviceToken] completion:^(NSError *error) {
+                [client.push registerNativeWithDeviceToken:deviceToken tags:@[deviceTokenString] completion:^(NSError *error) {
                     if (error) {
                         [test addLog:[NSString stringWithFormat:@"Encountered error registering with Mobile Service: %@", error.description]];
                         [test setTestStatus:TSFailed];

--- a/test/iOS/ZumoE2ETestApp/ZumoE2ETestApp/ZumoTestStore.m
+++ b/test/iOS/ZumoE2ETestApp/ZumoE2ETestApp/ZumoTestStore.m
@@ -65,6 +65,8 @@ NSString * const ALL_UNATTENDED_TESTS_GROUP_NAME = @"All tests (unattended)";
                 ZumoTest *newTest = [[ZumoTest alloc] init];
                 [newTest setTestName:[test testName]];
                 [newTest setExecution:[test execution]];
+                newTest.requiredFeatures = test.requiredFeatures;
+                
                 [result addTest:newTest];
             }
         }


### PR DESCRIPTION
Have unattended tests copy required features array
Fix MSPush device token tag logic
