### PR TITLE
Remove date/time string from InvalidStringIds collection

### DIFF
--- a/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.Test/TestData/IdTestData.cs
+++ b/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.Test/TestData/IdTestData.cs
@@ -54,6 +54,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             "id\nwith\n\newline",
             "id with fowardslash \\",
             "id with backslash /",
+            "1/8/2010 8:00:00 AM",
             "\"idWithQuotes\"",
             "?",
             "\\",


### PR DESCRIPTION
The string `"2010-01-07 11:00:00 a.m."` no longer appears to be an invalid id according to the rules in `MobileServiceSerializer.GetId`.

Removing this value from the test data fixes nine currently failing tests.
