### PR TITLE
Added loading changed events funcionality to MobileServiceCollection

### DIFF
--- a/sdk/Managed/Microsoft.WindowsAzure.Mobile.Managed.sln
+++ b/sdk/Managed/Microsoft.WindowsAzure.Mobile.Managed.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30324.0
+VisualStudioVersion = 12.0.30723.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.WindowsAzure.Mobile", "src\Microsoft.WindowsAzure.MobileServices\Microsoft.WindowsAzure.Mobile.csproj", "{75557793-E36E-4190-8714-5BD2665859FB}"
 EndProject

--- a/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/Collections/MobileServiceCollection.cs
+++ b/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/Collections/MobileServiceCollection.cs
@@ -253,6 +253,19 @@ namespace Microsoft.WindowsAzure.MobileServices
         }
 
         /// <summary>
+        /// Occurs when <see cref="LoadMoreItemsAsync"/> 
+        /// starting to load items. 
+        /// </summary>
+        public event EventHandler LoadingItems;
+
+        /// <summary>
+        /// Occurs when finished loading items. Provides 
+        /// <see cref="LoadingCompleteEventArgs"/> with 
+        /// how many items were loaded.  
+        /// </summary>
+        public event EventHandler<LoadingCompleteEventArgs> LoadingComplete;
+
+        /// <summary>
         /// Load more items asynchronously.
         /// Controls which support incremental loading on such as GridView on Windows 8 
         /// call this method automatically.
@@ -260,7 +273,7 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// </summary>
         /// <param name="count">
         /// The number of items to load.
-        /// This parameter overrides the pageSize specified in the constructore.
+        /// This parameter overrides the pageSize specified in the constructor.
         /// </param>
         /// <returns>The result of loading the items.</returns>
         public Task<int> LoadMoreItemsAsync(int count = 0)
@@ -279,7 +292,7 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// </param>
         /// <param name="count">
         /// The number of items to load.
-        /// This parameter overrides the pageSize specified in the constructore.
+        /// This parameter overrides the pageSize specified in the constructor.
         /// </param>
         /// <returns>The result of loading the items.</returns>
         public async Task<int> LoadMoreItemsAsync(CancellationToken token, int count = 0)
@@ -288,7 +301,13 @@ namespace Microsoft.WindowsAzure.MobileServices
             {
                 throw new InvalidOperationException(Resources.MobileServiceCollection_LoadInProcess);
             }
+
             busy = true;
+
+            EventHandler loadingItems = LoadingItems;
+            if (loadingItems != null) { loadingItems(this, new EventArgs()); }
+
+            int results = 0;
 
             try
             {
@@ -314,7 +333,7 @@ namespace Microsoft.WindowsAzure.MobileServices
                     this.HasMoreItems = false;
                 }
 
-                int results = await this.ProcessQueryAsync(token, query);
+                results = await this.ProcessQueryAsync(token, query);
 
                 if (results == 0)
                 {
@@ -336,6 +355,9 @@ namespace Microsoft.WindowsAzure.MobileServices
             finally
             {
                 busy = false;
+
+                EventHandler<LoadingCompleteEventArgs> loadingComplete = LoadingComplete;
+                if (loadingComplete != null) { loadingComplete(this, new LoadingCompleteEventArgs() { TotalItemsLoaded = results }); }
             }
         }
 

--- a/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/Collections/MobileServiceCollectionEventArgs.cs
+++ b/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/Collections/MobileServiceCollectionEventArgs.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Microsoft.WindowsAzure.MobileServices
+{
+    /// <summary>
+    /// Represents the loaded status changed event arguments.
+    /// </summary>
+    public class LoadingCompleteEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Provides how many items were loaded.
+        /// </summary>
+        public int TotalItemsLoaded { get; set; }
+    }
+}

--- a/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/Microsoft.WindowsAzure.Mobile.csproj
+++ b/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/Microsoft.WindowsAzure.Mobile.csproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <Compile Include="Authentication\MobileServiceTokenAuthentication.cs" />
     <Compile Include="Collections\MobileServiceCollection.cs" />
+    <Compile Include="Collections\MobileServiceCollectionEventArgs.cs" />
     <Compile Include="EnumValueAttribute.cs" />
     <Compile Include="Exceptions\MobileServiceConflictException.cs" />
     <Compile Include="Exceptions\MobileServiceInvalidOperationException.cs" />

--- a/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.Test/UnitTests/Collections/MobileServiceCollection.Test.cs
+++ b/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.Test/UnitTests/Collections/MobileServiceCollection.Test.cs
@@ -343,5 +343,62 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             Assert.IsTrue(properties.SequenceEqual(expectedProperties));
             Assert.IsTrue(actions.SequenceEqual(expectedActions));
         }
+
+        [AsyncTestMethod]
+        public async Task MobileServiceCollectionLoadMoreItemsAsyncFiresLoadingItemsEventBeforeReadingData()
+        {
+            // Get the Books table
+            MobileServiceTableQueryMock<Book> query = new MobileServiceTableQueryMock<Book>();
+
+            MobileServiceCollection<Book, Book> collection = new MobileServiceCollection<Book, Book>(query);
+            CancellationTokenSource tokenSource = new CancellationTokenSource();
+
+            Exception ex = null;
+
+            bool firedLoading = false;
+
+            collection.LoadingItems += (s, e) => firedLoading = true;
+
+            try
+            {
+                int result = await collection.LoadMoreItemsAsync(tokenSource.Token);
+            }
+            catch (Exception e)
+            {
+                ex = e;
+            }
+
+            Assert.IsTrue(firedLoading);
+            Assert.IsNull(ex);
+
+        }
+
+        [AsyncTestMethod]
+        public async Task MobileServiceCollectionLoadMoreItemsAsyncFiresLoadingCompleteEventAfterReadingData()
+        {
+            // Get the Books table
+            MobileServiceTableQueryMock<Book> query = new MobileServiceTableQueryMock<Book>();
+
+            MobileServiceCollection<Book, Book> collection = new MobileServiceCollection<Book, Book>(query);
+            CancellationTokenSource tokenSource = new CancellationTokenSource();
+
+            Exception ex = null;
+
+            int loadedEventArgsManyItemsLoaded = 0;
+            collection.LoadingComplete += (s, e) => loadedEventArgsManyItemsLoaded = e.TotalItemsLoaded;
+
+            try
+            {
+                int result = await collection.LoadMoreItemsAsync(tokenSource.Token);
+            }
+            catch (Exception e)
+            {
+                ex = e;
+            }
+
+            Assert.AreEqual(loadedEventArgsManyItemsLoaded, 2);
+            Assert.IsNull(ex);
+
+        }    
     }
 }


### PR DESCRIPTION
Added loading changed events funcionality to MobileServiceCollection and derivatives.

Feedback:
http://feedback.azure.com/forums/216254-mobile-services/suggestions/5936120-add-isloadingchanged-event-delegate-in-gettable-in
