### PR TITLE
[iOS] import Foundation framework to resolve errors with unknown type

### DIFF
--- a/sdk/iOS/src/MSError.h
+++ b/sdk/iOS/src/MSError.h
@@ -5,6 +5,7 @@
 #ifndef WindowsAzureMobileServices_MSError_h
 #define WindowsAzureMobileServices_MSError_h
 
+#import <Foundation/Foundation.h>
 
 #pragma mark * MSErrorDomain
 


### PR DESCRIPTION
As requested in #402 to merge this into the dev branch. 

Again, should resolve issues with #74 
