### PR TITLE
[client][ios] fixing a crash when a key is 1 character length in a a pre...

### DIFF
--- a/sdk/iOS/src/MSJSONSerializer.m
+++ b/sdk/iOS/src/MSJSONSerializer.m
@@ -451,7 +451,7 @@ static NSArray *allIdKeys;
         
         if(removeSystemProperties) {
             NSSet *systemProperties = [preSerializedItem keysOfEntriesPassingTest:^BOOL(id key, id obj, BOOL *stop) {
-                return [[key substringToIndex:2] isEqualToString:@"__"];
+                return [key length] > 1 && [[key substringToIndex:2] isEqualToString:@"__"];
             }];
             [preSerializedItem removeObjectsForKeys:[systemProperties allObjects]];
         }


### PR DESCRIPTION
Hello,

When the key of an item has a 1 character length, the class MSJSONSerializer crashes.
For example :
{
  "title" : "Hello",
  "x" : 12.5,
  "y" : 15.10
}
