### PR TITLE
[iOS] Fix issue with errors on invalid items

### DIFF
--- a/sdk/iOS/src/MSTableOperationError.m
+++ b/sdk/iOS/src/MSTableOperationError.m
@@ -121,8 +121,17 @@
     }
     
     MSJSONSerializer *serializer = [MSJSONSerializer new];
-    NSData *data = [serializer dataFromItem:properties idAllowed:YES ensureDictionary:NO removeSystemProperties:NO orError:nil];
+    NSError *serializeError;
+    NSData *data = [serializer dataFromItem:properties idAllowed:YES ensureDictionary:NO removeSystemProperties:NO orError:&serializeError];
     
+    // Handle if something is wrong with one of our fields, try again without the possibly breaking fields
+    if (serializeError.code == MSInvalidItemWithRequest) {
+        [properties removeObjectForKey:@"item"];
+        [properties removeObjectForKey:@"serverItem"];
+        
+        data = [serializer dataFromItem:properties idAllowed:YES ensureDictionary:NO removeSystemProperties:NO orError:&serializeError];
+    }
+        
     return @{ @"id": self.guid, @"properties": data };
 }
 

--- a/sdk/iOS/test/CoreDataTestModel.xcdatamodeld/CoreDataTestModel.xcdatamodel/contents
+++ b/sdk/iOS/test/CoreDataTestModel.xcdatamodeld/CoreDataTestModel.xcdatamodel/contents
@@ -1,5 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="5064" systemVersion="13D65" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6244" systemVersion="14A386a" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
+    <entity name="ColumnTypes" syncable="YES">
+        <attribute name="binary" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="boolean" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="date" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="decimal" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="double" optional="YES" attributeType="Double" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="float" optional="YES" attributeType="Float" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="id" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="int16" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="int32" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="int64" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
+        <attribute name="string" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
     <entity name="ManySystemColumns" syncable="YES">
         <attribute name="id" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="ms_createdAt" optional="YES" attributeType="Date" syncable="YES"/>
@@ -30,10 +43,11 @@
         <attribute name="text" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
     <elements>
+        <element name="ColumnTypes" positionX="-54" positionY="54" width="128" height="208"/>
+        <element name="ManySystemColumns" positionX="-54" positionY="27" width="128" height="148"/>
         <element name="MS_TableOperationErrors" positionX="-45" positionY="27" width="128" height="75"/>
         <element name="MS_TableOperations" positionX="-54" positionY="18" width="128" height="103"/>
         <element name="TodoItem" positionX="-63" positionY="-18" width="128" height="103"/>
         <element name="TodoNoVersion" positionX="-45" positionY="18" width="128" height="73"/>
-        <element name="ManySystemColumns" positionX="-54" positionY="27" width="128" height="148"/>
     </elements>
 </model>


### PR DESCRIPTION
When attempting to sync a table with a binary column (which can't be JSON serialized error) the application crashed and the error was unhelpful. This log updates the framework to better handle all invalid item errors (primarily for cases where the error is not setup but somehow corrupted/unexpected values)
