### PR TITLE
[JS] Unmangle variable names for now

### DIFF
--- a/sdk/Javascript/Gruntfile.js
+++ b/sdk/Javascript/Gruntfile.js
@@ -93,7 +93,8 @@ module.exports = function(grunt) {
     },
     uglify: {
       options: {
-        banner: '//! Copyright (c) Microsoft Corporation. All rights reserved. <%= pkg.name %> v<%= pkg.version %>\n'
+          banner: '//! Copyright (c) Microsoft Corporation. All rights reserved. <%= pkg.name %> v<%= pkg.version %>\n',
+          mangle: false
       },
       web: {
         src: 'src/Generated/MobileServices.Web.js',


### PR DESCRIPTION
Min file was breaking when using where clauses (most likely with an issue with how esprima or queryjs is being mangled). So turning off mangling for now, probably need to rework how min file is made to only not mangle esprima/query.js modules.
