### PR TITLE
Codesigning Android JAR files & Publishing to jCenter

### DIFF
--- a/sdk/android/android-libraries.gradle
+++ b/sdk/android/android-libraries.gradle
@@ -1,0 +1,55 @@
+apply plugin: 'maven'
+
+def myProject = project
+
+// step 2
+uploadArchives {
+    repositories.mavenDeployer {
+        pom.groupId = myProject.group
+        pom.artifactId = PUBLISH_ARTIFACT_ID
+        pom.version = myProject.version
+        repository (
+                url: 'https://api.bintray.com/maven/azuremobileservices/SDK/Mobile-Services-Android-SDK'
+        ) {
+            authentication(
+                    userName: 'username',
+                    password: 'key'
+            )
+        }
+    }
+}
+
+task clearJar(type: Delete) {
+    delete 'build/release/' + PUBLISH_ARTIFACT_ID + '-' + myProject.version + '.jar'
+}
+
+// step 1
+task makeJar(type: Copy) {
+    from('build/intermediates/bundles/release/')
+    into('build/release/')
+    include('classes.jar')
+    rename ('classes.jar', PUBLISH_ARTIFACT_ID + '-' +  myProject.version + '.jar')
+}
+
+makeJar.dependsOn(clearJar, build)
+
+task androidJavadocs(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+}
+
+task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+    classifier = 'javadoc'
+    from androidJavadocs.destinationDir
+}
+
+task androidSourcesJar(type: Jar) {
+    classifier = 'sources'
+    from android.sourceSets.main.java.srcDirs
+}
+
+artifacts {
+    archives androidSourcesJar
+    archives androidJavadocsJar
+    archives file : file('build/release/' + PUBLISH_ARTIFACT_ID + '-' + myProject.version + '.jar')
+}

--- a/sdk/android/android-libraries.gradle
+++ b/sdk/android/android-libraries.gradle
@@ -12,8 +12,8 @@ uploadArchives {
                 url: 'https://api.bintray.com/maven/azuremobileservices/SDK/Mobile-Services-Android-SDK'
         ) {
             authentication(
-                    userName: 'username',
-                    password: 'key'
+                    userName: 'yuaxu',
+                    password: 'a7954536c3f8733e67a5159f672bcbdfbfb26e20'
             )
         }
     }

--- a/sdk/android/android-libraries.gradle
+++ b/sdk/android/android-libraries.gradle
@@ -12,8 +12,8 @@ uploadArchives {
                 url: 'https://api.bintray.com/maven/azuremobileservices/SDK/Mobile-Services-Android-SDK'
         ) {
             authentication(
-                    userName: 'yuaxu',
-                    password: 'a7954536c3f8733e67a5159f672bcbdfbfb26e20'
+                    userName: 'bintray username',
+                    password: 'bintray api key'
             )
         }
     }

--- a/sdk/android/build.gradle
+++ b/sdk/android/build.gradle
@@ -16,4 +16,9 @@ allprojects {
     repositories {
         jcenter()
     }
+
+    apply plugin: 'idea'
+
+    group = 'com.microsoft.azure'
+    version = '2.0-beta'
 }

--- a/sdk/android/src/notifications-handler/build.gradle
+++ b/sdk/android/src/notifications-handler/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'com.android.library'
 
+ext {
+    PUBLISH_ARTIFACT_ID = 'azure-notifications-handler'
+}
+
 android {
     compileSdkVersion 19
     buildToolsVersion "19.1.0"
@@ -27,3 +31,5 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.google.android.gms:play-services:3.1.+'
 }
+
+apply from : '../../android-libraries.gradle'

--- a/sdk/android/src/notifications-handler/notifications-handler.iml
+++ b/sdk/android/src/notifications-handler/notifications-handler.iml
@@ -60,6 +60,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/build/docs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
@@ -79,7 +80,9 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
+      <excludeFolder url="file://$MODULE_DIR$/build/libs" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/release" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 19 Platform" jdkType="Android SDK" />

--- a/sdk/android/src/sdk/build.gradle
+++ b/sdk/android/src/sdk/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'com.android.library'
 
+ext {
+    PUBLISH_ARTIFACT_ID = 'azure-mobile-services-android-sdk'
+}
+
 android {
     compileSdkVersion 19
     buildToolsVersion "19.1.0"
@@ -28,3 +32,5 @@ dependencies {
     compile 'com.google.code.gson:gson:2.3'
     compile 'com.google.guava:guava:18.0'
 }
+
+apply from : '../../android-libraries.gradle'

--- a/sdk/android/src/sdk/sdk.iml
+++ b/sdk/android/src/sdk/sdk.iml
@@ -60,6 +60,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/build/docs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
@@ -79,7 +80,10 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
+      <excludeFolder url="file://$MODULE_DIR$/build/libs" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/poms" />
+      <excludeFolder url="file://$MODULE_DIR$/build/release" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 19 Platform" jdkType="Android SDK" />

--- a/test/Android/ZumoE2ETestApp/ZumoE2ETestApp.iml
+++ b/test/Android/ZumoE2ETestApp/ZumoE2ETestApp.iml
@@ -79,6 +79,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 19 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/test/Android/ZumoE2ETestApp/ZumoE2ETestApp.iml
+++ b/test/Android/ZumoE2ETestApp/ZumoE2ETestApp.iml
@@ -79,7 +79,6 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 19 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />


### PR DESCRIPTION
sdk/android/android-libraries.gradle allows us to publish to jCenter (https://bintray.com/azuremobileservices/SDK/Mobile-Services-Android-SDK/2.0-beta/view) as long as you have a bintray account and is part of the azuremobileservices organization.

JAR files also codesigned.