### PR TITLE
[iOS] Helper function for NSManagedObject

### DIFF
--- a/sdk/iOS/WindowsAzureMobileServices.xcodeproj/project.pbxproj
+++ b/sdk/iOS/WindowsAzureMobileServices.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		870C0C9D199C246700A134DD /* MSSDKFeatures.m in Sources */ = {isa = PBXBuildFile; fileRef = 870C0C9B199C246700A134DD /* MSSDKFeatures.m */; };
 		A214410C182631A500C2E762 /* MSTableFuncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A214410B182631A500C2E762 /* MSTableFuncTests.m */; };
 		A22CF3731825914700660C79 /* MSTable+MSTableTestUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = A22CF3721825914700660C79 /* MSTable+MSTableTestUtilities.m */; };
+		A24425521A67496600854EF9 /* TodoItem.h in Headers */ = {isa = PBXBuildFile; fileRef = A24425501A67496600854EF9 /* TodoItem.h */; };
+		A24425531A67496600854EF9 /* TodoItem.m in Sources */ = {isa = PBXBuildFile; fileRef = A24425511A67496600854EF9 /* TodoItem.m */; };
 		A24701B7196896F500385DA2 /* MSLocalStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = A24701AD196896F500385DA2 /* MSLocalStorage.h */; };
 		A24701B8196896F500385DA2 /* MSLocalStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = A24701AE196896F500385DA2 /* MSLocalStorage.m */; };
 		A24701B9196896F500385DA2 /* MSPush.h in Headers */ = {isa = PBXBuildFile; fileRef = A24701AF196896F500385DA2 /* MSPush.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -181,6 +183,8 @@
 		A214410B182631A500C2E762 /* MSTableFuncTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSTableFuncTests.m; sourceTree = "<group>"; };
 		A22CF3711825914700660C79 /* MSTable+MSTableTestUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MSTable+MSTableTestUtilities.h"; sourceTree = "<group>"; };
 		A22CF3721825914700660C79 /* MSTable+MSTableTestUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MSTable+MSTableTestUtilities.m"; sourceTree = "<group>"; };
+		A24425501A67496600854EF9 /* TodoItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TodoItem.h; sourceTree = "<group>"; };
+		A24425511A67496600854EF9 /* TodoItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TodoItem.m; sourceTree = "<group>"; };
 		A24701AD196896F500385DA2 /* MSLocalStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSLocalStorage.h; sourceTree = "<group>"; };
 		A24701AE196896F500385DA2 /* MSLocalStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSLocalStorage.m; sourceTree = "<group>"; };
 		A24701AF196896F500385DA2 /* MSPush.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSPush.h; sourceTree = "<group>"; };
@@ -393,6 +397,8 @@
 				A28224B1192ACFB700EF8743 /* CoreDataTestModel.xcdatamodeld */,
 				A29F44A11953CBF30063C0C1 /* MSCoreDataStore+TestHelper.h */,
 				A29F44A21953CBF30063C0C1 /* MSCoreDataStore+TestHelper.m */,
+				A24425501A67496600854EF9 /* TodoItem.h */,
+				A24425511A67496600854EF9 /* TodoItem.m */,
 			);
 			name = CoreData;
 			sourceTree = "<group>";
@@ -683,6 +689,7 @@
 				A258890B18A19D0B00962F9A /* MSOperationQueue.h in Headers */,
 				CFAE6E0C1A3B84E400734128 /* MSTableConfigValue.h in Headers */,
 				CF1D745B1A5D9CAB0074789F /* MSQueuePurgeOperation.h in Headers */,
+				A24425521A67496600854EF9 /* TodoItem.h in Headers */,
 				E8C44042170BAD49002FC997 /* MSAPIConnection.h in Headers */,
 				A258891518A19D0B00962F9A /* MSSyncContextInternal.h in Headers */,
 				E8C44047170BAD93002FC997 /* MSAPIRequest.h in Headers */,
@@ -863,6 +870,7 @@
 				A24701BC196896F500385DA2 /* MSPushHttp.m in Sources */,
 				E8C44048170BAD93002FC997 /* MSAPIRequest.m in Sources */,
 				CF4D498C1A3253E2006AEB70 /* MSTestWaiter.m in Sources */,
+				A24425531A67496600854EF9 /* TodoItem.m in Sources */,
 				CF1D74591A5D85C60074789F /* MSQueuePurgeOperation.m in Sources */,
 				A2818FFD18BB0660001B14E7 /* MSQueuePushOperation.m in Sources */,
 				A24701B8196896F500385DA2 /* MSLocalStorage.m in Sources */,

--- a/sdk/iOS/src/MSCoreDataStore.h
+++ b/sdk/iOS/src/MSCoreDataStore.h
@@ -25,4 +25,14 @@
 
 /// @}
 
+#pragma mark * Helper functions
+
+/// @{name Working with the table APIs
+
+/// Converts a managed object from the core data layer back into a dictionary with the
+/// properties expected when using a MSTable or MSSyncTable
++(NSDictionary *) tableItemFromManagedObject:(NSManagedObject *)object;
+
+/// @}
+
 @end

--- a/sdk/iOS/src/MSCoreDataStore.m
+++ b/sdk/iOS/src/MSCoreDataStore.m
@@ -77,6 +77,27 @@ NSString *const StoreDeleted = @"ms_deleted";
     return [results firstObject];
 }
 
++(NSDictionary *) tableItemFromManagedObject:(NSManagedObject *)object
+{
+    NSArray *attributes = [object.entity.attributesByName allKeys];
+    NSMutableDictionary *serverItem = [[object dictionaryWithValuesForKeys:attributes] mutableCopy];
+
+    // Find all system columns in the item
+    NSSet *systemColumnNames = [serverItem keysOfEntriesPassingTest:^BOOL(id key, id obj, BOOL *stop) {
+        NSString *columnName = (NSString *)key;
+        return [columnName hasPrefix:StoreSystemColumnPrefix];
+    }];
+    
+    // Now translate every system column from ms_x to __x
+    for (NSString *columnName in systemColumnNames) {
+        NSString *adjustedName = [MSCoreDataStore externalNameForStoreColumnName:columnName];
+        serverItem[adjustedName] = serverItem[columnName];
+        [serverItem removeObjectForKey:columnName];
+    }
+    
+    return serverItem;
+}
+
 /// Helper function to convert a server (external) item to only contain the appropriate keys for storage
 /// in core data tables. This means we need to change system columns (prefix: __) to use ms_, and remove
 /// any retrieved columns from the user's schema that aren't in the local store's schema

--- a/sdk/iOS/test/CoreDataTestModel.xcdatamodeld/CoreDataTestModel.xcdatamodel/contents
+++ b/sdk/iOS/test/CoreDataTestModel.xcdatamodeld/CoreDataTestModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6252" systemVersion="13F34" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6254" systemVersion="14C81f" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
     <entity name="ColumnTypes" syncable="YES">
         <attribute name="binary" optional="YES" attributeType="Binary" syncable="YES"/>
         <attribute name="boolean" optional="YES" attributeType="Boolean" syncable="YES"/>
@@ -42,7 +42,7 @@
         <attribute name="table" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="tableKind" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
     </entity>
-    <entity name="TodoItem" syncable="YES">
+    <entity name="TodoItem" representedClassName="TodoItem" syncable="YES">
         <attribute name="id" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="ms_version" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="sort" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
@@ -58,7 +58,7 @@
         <element name="MS_TableConfig" positionX="160" positionY="192" width="128" height="118"/>
         <element name="MS_TableOperationErrors" positionX="153" positionY="-189" width="128" height="103"/>
         <element name="MS_TableOperations" positionX="-63" positionY="-189" width="128" height="118"/>
-        <element name="TodoItem" positionX="-324" positionY="-45" width="128" height="103"/>
+        <element name="TodoItem" positionX="-324" positionY="-45" width="128" height="105"/>
         <element name="TodoNoVersion" positionX="-234" positionY="-126" width="128" height="73"/>
     </elements>
 </model>

--- a/sdk/iOS/test/TodoItem.h
+++ b/sdk/iOS/test/TodoItem.h
@@ -1,0 +1,15 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+@interface TodoItem : NSManagedObject
+
+@property (nonatomic, retain) NSString * id;
+@property (nonatomic, retain) NSString * ms_version;
+@property (nonatomic, retain) NSNumber * sort;
+@property (nonatomic, retain) NSString * text;
+
+@end

--- a/sdk/iOS/test/TodoItem.m
+++ b/sdk/iOS/test/TodoItem.m
@@ -1,0 +1,14 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+#import "TodoItem.h"
+
+@implementation TodoItem
+
+@dynamic id;
+@dynamic ms_version;
+@dynamic sort;
+@dynamic text;
+
+@end


### PR DESCRIPTION
Expose a helper function on MSCoreDataStore that makes it simple to go
from a NSManagedObject back to the expected dictionary format.