### PR TITLE
[iOS] Moving scope of internal headers

### DIFF
--- a/sdk/iOS/src/MSAPIRequest.h
+++ b/sdk/iOS/src/MSAPIRequest.h
@@ -3,7 +3,7 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSClientInternal.h"
+#import "MSClient.h"
 #import "MSSerializer.h"
 
 

--- a/sdk/iOS/src/MSAPIRequest.m
+++ b/sdk/iOS/src/MSAPIRequest.m
@@ -5,6 +5,7 @@
 #import "MSAPIRequest.h"
 #import "MSURLBuilder.h"
 #import "MSSDKFeatures.h"
+#import "MSClientInternal.h"
 
 #pragma mark * MSAPIRequest Implementation
 

--- a/sdk/iOS/src/MSClientConnection.h
+++ b/sdk/iOS/src/MSClientConnection.h
@@ -3,7 +3,7 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSClientInternal.h"
+#import "MSClient.h"
 #import "MSSerializer.h"
 
 

--- a/sdk/iOS/src/MSClientConnection.m
+++ b/sdk/iOS/src/MSClientConnection.m
@@ -6,7 +6,7 @@
 #import "MSUserAgentBuilder.h"
 #import "MSFilter.h"
 #import "MSUser.h"
-
+#import "MSClientInternal.h"
 
 #pragma mark * HTTP Header String Constants
 

--- a/sdk/iOS/src/MSPushHttp.m
+++ b/sdk/iOS/src/MSPushHttp.m
@@ -4,7 +4,7 @@
 
 #import "MSPushRequest.h"
 #import "MSPushHttp.h"
-#import "MSClient.h"
+#import "MSClientInternal.h"
 
 @interface MSPushHttp ()
 @property (nonatomic, weak, readonly) MSClient *client;

--- a/sdk/iOS/src/MSTableConnection.m
+++ b/sdk/iOS/src/MSTableConnection.m
@@ -5,6 +5,7 @@
 #import "MSTableConnection.h"
 #import "MSSerializer.h"
 #import "MSQueryResult.h"
+#import "MSClientInternal.h"
 
 // next link is the format "http://contoso.com; rel=next"
 static NSString *const nextLinkPattern = @"^(.*?);\\s*rel\\s*=\\s*(\\w+)\\s*"; // $1; rel = $2

--- a/sdk/iOS/src/MSTableRequest.m
+++ b/sdk/iOS/src/MSTableRequest.m
@@ -5,7 +5,7 @@
 #import "MSTableRequest.h"
 #import "MSURLBuilder.h"
 #import "MSSDKFeatures.h"
-
+#import "MSClientInternal.h"
 
 #pragma mark * HTTP Method String Constants
 

--- a/sdk/iOS/src/MSURLBuilder.h
+++ b/sdk/iOS/src/MSURLBuilder.h
@@ -3,7 +3,7 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSClientInternal.h"
+#import "MSClient.h"
 #import "MSTable.h"
 #import "MSQuery.h"
 


### PR DESCRIPTION
Moving all internal header usage to implementation files to hide from public scope.

I was testing with CocoaPods upcoming framework feature in their next release. Setting all internal headers to project scope using this I had errors with the internal headers used in the public headers not being available. I assume this is now closer to what is actually intended with internal headers.