### PR TITLE
Fix systemProperties name in SyncContext

### DIFF
--- a/sdk/iOS/src/MSCoreDataStore.m
+++ b/sdk/iOS/src/MSCoreDataStore.m
@@ -159,7 +159,7 @@ NSString *const StoreDeleted = @"ms_deleted";
 
 #pragma mark - MSSyncContextDataSource
 
--(NSUInteger) systemPropetiesForTable:(NSString *)table
+-(NSUInteger) systemPropertiesForTable:(NSString *)table
 {
     MSSystemProperties properties = MSSystemPropertyNone;
     NSEntityDescription *entity = [NSEntityDescription entityForName:table

--- a/sdk/iOS/src/MSSyncContext.h
+++ b/sdk/iOS/src/MSSyncContext.h
@@ -85,7 +85,7 @@ typedef void (^MSSyncPushCompletionBlock)(void);
 
 /// Returns the MSSystemProperties that should be stored locally (example: __createdAt, __updatedAt)
 /// If not implemented, the default of __version will be asked for from the server
--(NSUInteger) systemPropetiesForTable:(NSString *)table;
+-(NSUInteger) systemPropertiesForTable:(NSString *)table;
 
 /// @}
 

--- a/sdk/iOS/src/MSSyncContext.m
+++ b/sdk/iOS/src/MSSyncContext.m
@@ -358,8 +358,8 @@ static NSOperationQueue *pushQueue_;
     }
     
     // Get the required system properties from the Store
-    if ([self.dataSource respondsToSelector:@selector(systemPropetiesForTable:)]) {
-        queryCopy.table.systemProperties = [self.dataSource systemPropetiesForTable:queryCopy.table.name];
+    if ([self.dataSource respondsToSelector:@selector(systemPropertiesForTable:)]) {
+        queryCopy.table.systemProperties = [self.dataSource systemPropertiesForTable:queryCopy.table.name];
     } else {
         queryCopy.table.systemProperties = MSSystemPropertyVersion;
     }

--- a/sdk/iOS/src/MSTableOperation.m
+++ b/sdk/iOS/src/MSTableOperation.m
@@ -79,8 +79,8 @@
     MSTable *table = [self.client tableWithName:self.tableName];
     table.features = MSFeatureOffline;
     
-    if ([self.dataSource respondsToSelector:@selector(systemPropetiesForTable:)]) {
-        table.systemProperties = [self.dataSource systemPropetiesForTable:self.tableName];
+    if ([self.dataSource respondsToSelector:@selector(systemPropertiesForTable:)]) {
+        table.systemProperties = [self.dataSource systemPropertiesForTable:self.tableName];
     } else {
         table.systemProperties = MSSystemPropertyVersion;
     }

--- a/sdk/iOS/test/MSCoreDataStoreTests.m
+++ b/sdk/iOS/test/MSCoreDataStoreTests.m
@@ -450,13 +450,13 @@
 
 -(void)testSystemProperties
 {
-    MSSystemProperties properties = [self.store systemPropetiesForTable:@"ManySystemColumns"];
+    MSSystemProperties properties = [self.store systemPropertiesForTable:@"ManySystemColumns"];
     XCTAssertEqual(properties, MSSystemPropertyCreatedAt | MSSystemPropertyUpdatedAt | MSSystemPropertyVersion | MSSystemPropertyDeleted);
 
-    properties = [self.store systemPropetiesForTable:@"TodoItem"];
+    properties = [self.store systemPropertiesForTable:@"TodoItem"];
     XCTAssertEqual(properties, MSSystemPropertyVersion);
 
-    properties = [self.store systemPropetiesForTable:@"TodoItemNoVersion"];
+    properties = [self.store systemPropertiesForTable:@"TodoItemNoVersion"];
     XCTAssertEqual(properties, MSSystemPropertyNone);
 }
 


### PR DESCRIPTION
Fixing spelling error on property name. 

There was an open issue, but I can't find it presently.  No functional differences.