### PR TITLE
iOS: Add Gateway Support

### DIFF
--- a/sdk/iOS/src/MSClient.h
+++ b/sdk/iOS/src/MSClient.h
@@ -42,8 +42,11 @@ typedef void (^MSAPIDataBlock)(NSData *result,
 /// @name Properties
 /// @{
 
-/// The URL of the Microsoft Azure Mobile Service associated with the client.
-@property (nonatomic, strong, readonly)     NSURL *applicationURL;
+/// The URL of the Microsoft Azure Mobile App
+@property (nonatomic, strong, readonly) NSURL *applicationURL;
+
+/// The URL of the gateway associated with the mobile app
+@property (nonatomic, strong, readonly) NSURL *gatewayURL;
 
 /// The application key for the Microsoft Azure Mobile Service associated with
 /// the client if one was provided in the creation of the client and nil
@@ -51,13 +54,13 @@ typedef void (^MSAPIDataBlock)(NSData *result,
 /// made to the Microsoft Azure Mobile Service, allowing the client to perform
 /// all actions on the Microsoft Azure Mobile Service that require application-key
 /// level permissions.
-@property (nonatomic, copy, readonly)     NSString *applicationKey;
+@property (nonatomic, copy, readonly) NSString *applicationKey;
 
 /// A collection of MSFilter instances to apply to use with the requests and
 /// responses sent and received by the client. The property is readonly and the
 /// array is not-mutable. To apply a filter to a client, use the withFilter:
 /// method.
-@property (nonatomic, strong, readonly)         NSArray *filters;
+@property (nonatomic, strong, readonly) NSArray *filters;
 
 /// A sync context that defines how offline data is synced and allows for manually
 /// syncing data on demand
@@ -66,7 +69,7 @@ typedef void (^MSAPIDataBlock)(NSData *result,
 /// @name Registering and unregistering for push notifications
 
 /// The property to use for registering and unregistering for notifications via *MSPush*.
-@property (nonatomic, strong, readonly)     MSPush *push;
+@property (nonatomic, strong, readonly) MSPush *push;
 
 /// @}
 
@@ -76,7 +79,7 @@ typedef void (^MSAPIDataBlock)(NSData *result,
 /// The currently logged in user. While the currentUser property can be set
 /// directly, the login* and logout methods are more convenient and
 /// recommended for non-testing use.
-@property (nonatomic, strong)               MSUser *currentUser;
+@property (nonatomic, strong) MSUser *currentUser;
 
 /// @}
 
@@ -93,12 +96,12 @@ typedef void (^MSAPIDataBlock)(NSData *result,
 +(MSClient *)clientWithApplicationURLString:(NSString *)urlString
                          applicationKey:(NSString *)key;
 
-/// Old method to create a client with the given URL and application key for the
-/// Microsoft Azure Mobile Service. This has been deprecated. Use
-/// clientWithApplicationURLString:applicationKey:
-/// @deprecated
-+(MSClient *)clientWithApplicationURLString:(NSString *)urlString
-                         withApplicationKey:(NSString *)key __deprecated;
+/// Creates a client with the given URL and application key for the Microsoft Azure
+/// Mobile Service.
++(MSClient *)clientWithApplicationURLString:(NSString *)applicationUrlString
+                           gatewayURLString:(NSString *)gatewayUrlString
+                             applicationKey:(NSString *)key;
+
 
 /// Creates a client with the given URL for the Microsoft Azure Mobile Service.
 +(MSClient *)clientWithApplicationURL:(NSURL *)url;
@@ -108,6 +111,13 @@ typedef void (^MSAPIDataBlock)(NSData *result,
 +(MSClient *)clientWithApplicationURL:(NSURL *)url
                        applicationKey:(NSString *)key;
 
+/// Creates a client with the given URL and application key for the Microsoft Azure
+/// Mobile Service.
++(MSClient *)clientWithApplicationURL:(NSURL *)applicationUrl
+                           gatewayURL:(NSURL *)gatewayUrl
+                       applicationKey:(NSString *)key;
+
+
 #pragma  mark * Public Initializer Methods
 
 /// Initializes a client with the given URL for the Microsoft Azure Mobile Service.
@@ -116,6 +126,13 @@ typedef void (^MSAPIDataBlock)(NSData *result,
 /// Initializes a client with the given URL and application key for the Windows
 /// Azure Mobile Service.
 -(id)initWithApplicationURL:(NSURL *)url applicationKey:(NSString *)key;
+
+/// Initializes a client with the given URL and application key for the Windows
+/// Azure Mobile Service.
+-(id)initWithApplicationURL:(NSURL *)applicationUrl
+                 gatewayURL:(NSURL *)gatewayUrl
+             applicationKey:(NSString *)key;
+
 
 #pragma mark * Public Filter Methods
 

--- a/sdk/iOS/src/MSClient.m
+++ b/sdk/iOS/src/MSClient.m
@@ -293,7 +293,8 @@
 {
     MSClient *client = [[MSClient allocWithZone:zone]
                             initWithApplicationURL:self.applicationURL
-                                applicationKey:self.applicationKey];
+                                        gatewayURL:self.gatewayURL
+                                    applicationKey:self.applicationKey];
                                                                             
     client.currentUser = [self.currentUser copyWithZone:zone];
     client.filters = [self.filters copyWithZone:zone];

--- a/sdk/iOS/src/MSError.h
+++ b/sdk/iOS/src/MSError.h
@@ -182,6 +182,10 @@ extern NSString *const MSErrorPushResultKey;
 /// Indicates that the login operation failed because an invalid token was used.
 #define MSLoginInvalidToken                     -1505
 
+/// Indicates that the login operation failed because the gateway URL in the client
+/// was invalid.
+#define MSLoginInvalidURL                       -1506
+
 /// Indicates that a required parameter for push operation was not provided
 #define MSPushRequiredParameter                 -1600
 

--- a/sdk/iOS/src/MSLogin.m
+++ b/sdk/iOS/src/MSLogin.m
@@ -53,6 +53,16 @@
     __block MSUser *localUser = nil;
     __block NSError *localError = nil;
     __block int allDoneCount = 0;
+  
+    // Verify we have a gateway URL
+    
+    if (![self verifyGatewayURL:self.client.gatewayURL error:&localError]) {
+        if (completion) {
+            completion(nil, localError);
+        }
+        return;
+    }
+
     
     void (^callCompletionIfAllDone)() = ^{
         allDoneCount++;
@@ -103,6 +113,8 @@
 -(MSLoginController *) loginViewControllerWithProvider:(NSString *)provider
                                             completion:(MSClientLoginBlock)completion
 {
+    NSAssert(self.client.gatewayURL != nil, @"The gateway URL is required for login");
+    
     provider = [self normalizeProvider:provider];
     return [[MSLoginController alloc] initWithClient:self.client
                                             provider:provider
@@ -180,6 +192,18 @@
 
 #pragma mark * Private Methods
 
+- (BOOL) verifyGatewayURL:(NSURL *)url error:(NSError **)error
+{
+    if (!url) {
+        *error = [NSError errorWithDomain:MSErrorDomain
+                                     code:MSLoginInvalidURL
+                                 userInfo:@{ NSLocalizedDescriptionKey :@"The gateway URL is required for login" }];
+        return NO;
+    }
+    
+    return YES;
+}
+
 -(NSString *) normalizeProvider:(NSString *)provider {
     // Microsoft Azure Active Directory can be specified either in
     // full or with the 'aad' abbreviation. The service REST API
@@ -197,11 +221,15 @@
 {
     NSMutableURLRequest *request = nil;
     
+    if (![self verifyGatewayURL:self.client.gatewayURL error:error]) {
+        return nil;
+    }
+
     NSData *requestBody = [[MSLoginSerializer loginSerializer] dataFromToken:token
                                                                      orError:error];
     if (requestBody) {
     
-        NSURL *URL = [self.client.applicationURL URLByAppendingPathComponent:
+        NSURL *URL = [self.client.gatewayURL URLByAppendingPathComponent:
                              [NSString stringWithFormat:@"login/%@", provider]];
         request = [NSMutableURLRequest requestWithURL:URL];
         request.HTTPMethod = @"POST";

--- a/sdk/iOS/src/MSLoginController.m
+++ b/sdk/iOS/src/MSLoginController.m
@@ -155,7 +155,11 @@
     if (!loginView) {
         
         // Ensure we are using HTTPS
-        NSURL *baseUrl = self.client.applicationURL;
+        NSURL *baseUrl = self.client.gatewayURL;
+        if (!baseUrl) {
+            baseUrl = self.client.applicationURL;
+        }
+        
         if ([[baseUrl.scheme lowercaseString] isEqualToString:@("http")])
         {
             NSString *baseUrlString = baseUrl.absoluteURL.absoluteString;

--- a/sdk/iOS/src/MSLoginController.m
+++ b/sdk/iOS/src/MSLoginController.m
@@ -156,10 +156,6 @@
         
         // Ensure we are using HTTPS
         NSURL *baseUrl = self.client.gatewayURL;
-        if (!baseUrl) {
-            baseUrl = self.client.applicationURL;
-        }
-        
         if ([[baseUrl.scheme lowercaseString] isEqualToString:@("http")])
         {
             NSString *baseUrlString = baseUrl.absoluteURL.absoluteString;

--- a/sdk/iOS/src/MSLoginView.m
+++ b/sdk/iOS/src/MSLoginView.m
@@ -145,7 +145,7 @@ NSString *const MSLoginViewErrorResponseData = @"com.Microsoft.WindowsAzureMobil
         // Check if this request is to the Microsoft Azure Mobile Service and
         // if so, make the request with the MSClientConnection so that we
         // can inspect the response
-        NSString *appURLString = self.client.applicationURL.absoluteString;
+        NSString *appURLString = self.client.gatewayURL.absoluteString;
         if ([self.currentURL isEqual:requestURL] ||
             [requestURLString rangeOfString:appURLString].location != 0)
         {


### PR DESCRIPTION
The new gateway URL will be used only for authentication workflows.