### PR TITLE
Fix for race condition in issue #622

### DIFF
--- a/sdk/android/src/sdk/src/main/java/com/microsoft/windowsazure/mobileservices/table/sync/localstore/SQLiteLocalStore.java
+++ b/sdk/android/src/sdk/src/main/java/com/microsoft/windowsazure/mobileservices/table/sync/localstore/SQLiteLocalStore.java
@@ -52,6 +52,8 @@ import java.util.Map.Entry;
  */
 public class SQLiteLocalStore extends SQLiteOpenHelper implements MobileServiceLocalStore {
     private Map<String, Map<String, ColumnDataInfo>> mTables;
+	private int mConcurrencyCount;
+	private Object mConcurrencyLock;
 
     /**
      * Constructor for SQLiteLocalStore
@@ -68,6 +70,8 @@ public class SQLiteLocalStore extends SQLiteOpenHelper implements MobileServiceL
     public SQLiteLocalStore(Context context, String name, CursorFactory factory, int version) {
         super(context, name, factory, version);
         this.mTables = new HashMap<String, Map<String, ColumnDataInfo>>();
+		this.mConcurrencyCount = 0;
+		this.mConcurrencyLock = new Object();
     }
 
     /**
@@ -92,16 +96,16 @@ public class SQLiteLocalStore extends SQLiteOpenHelper implements MobileServiceL
 
     @Override
     public void initialize() throws MobileServiceLocalStoreException {
+		SQLiteDatabase db = this.getWritableDatabaseSynchronized();
         try {
-            SQLiteDatabase db = this.getWritableDatabase();
-            db.close();
-
             for (Entry<String, Map<String, ColumnDataInfo>> entry : this.mTables.entrySet()) {
-                createTableFromObject(entry.getKey(), entry.getValue());
+                createTableFromObject(db, entry.getKey(), entry.getValue());
             }
         } catch (Throwable t) {
             throw new MobileServiceLocalStoreException(t);
-        }
+        } finally {
+			this.closeDatabaseSynchronized(db);
+		}
     }
 
     @Override
@@ -149,7 +153,7 @@ public class SQLiteLocalStore extends SQLiteOpenHelper implements MobileServiceL
 
             Integer inlineCount = null;
 
-            SQLiteDatabase db = this.getWritableDatabase();
+			SQLiteDatabase db = this.getWritableDatabaseSynchronized();
 
             try {
                 Cursor cursor = null;
@@ -180,7 +184,7 @@ public class SQLiteLocalStore extends SQLiteOpenHelper implements MobileServiceL
                     }
                 }
             } finally {
-                db.close();
+				this.closeDatabaseSynchronized(db);
             }
 
             if (query.hasInlineCount()) {
@@ -206,8 +210,8 @@ public class SQLiteLocalStore extends SQLiteOpenHelper implements MobileServiceL
 
             Map<String, ColumnDataInfo> table = this.mTables.get(invTableName);
 
-            SQLiteDatabase db = this.getWritableDatabase();
-
+            SQLiteDatabase db = this.getWritableDatabaseSynchronized();
+			
             try {
                 Cursor cursor = null;
 
@@ -223,7 +227,7 @@ public class SQLiteLocalStore extends SQLiteOpenHelper implements MobileServiceL
                     }
                 }
             } finally {
-                db.close();
+                this.closeDatabaseSynchronized(db);
             }
 
             return result;
@@ -281,12 +285,12 @@ public class SQLiteLocalStore extends SQLiteOpenHelper implements MobileServiceL
                 if (fromServer && statement.sql == "")
                     return;
 
-                SQLiteDatabase db = this.getWritableDatabase();
+                SQLiteDatabase db = this.getWritableDatabaseSynchronized();
 
                 try {
                     db.execSQL(statement.sql, statement.parameters.toArray());
                 } finally {
-                    db.close();
+                    this.closeDatabaseSynchronized(db);
                 }
 
                 pendingItems -= pageSize;
@@ -302,12 +306,12 @@ public class SQLiteLocalStore extends SQLiteOpenHelper implements MobileServiceL
         try {
             String invTableName = normalizeTableName(tableName);
 
-            SQLiteDatabase db = this.getWritableDatabase();
+            SQLiteDatabase db = this.getWritableDatabaseSynchronized();
 
             try {
                 db.delete(invTableName, "id = '" + itemId + "'", null);
             } finally {
-                db.close();
+                this.closeDatabaseSynchronized(db);
             }
         } catch (Throwable t) {
             throw new MobileServiceLocalStoreException(t);
@@ -319,14 +323,14 @@ public class SQLiteLocalStore extends SQLiteOpenHelper implements MobileServiceL
         try {
             String invTableName = normalizeTableName(tableName);
 
-            SQLiteDatabase db = this.getWritableDatabase();
+            SQLiteDatabase db = this.getWritableDatabaseSynchronized();
 
             try {
                 for (String itemId : itemsIds) {
                     db.delete(invTableName, "id = '" + itemId + "'", null);
                 }
             } finally {
-                db.close();
+                this.closeDatabaseSynchronized(db);
             }
         } catch (Throwable t) {
             throw new MobileServiceLocalStoreException(t);
@@ -340,12 +344,12 @@ public class SQLiteLocalStore extends SQLiteOpenHelper implements MobileServiceL
 
             String whereClause = getWhereClause(query);
 
-            SQLiteDatabase db = this.getWritableDatabase();
+            SQLiteDatabase db = this.getWritableDatabaseSynchronized();
 
             try {
                 db.delete(invTableName, whereClause, null);
             } finally {
-                db.close();
+                this.closeDatabaseSynchronized(db);
             }
         } catch (Throwable t) {
             throw new MobileServiceLocalStoreException(t);
@@ -618,9 +622,7 @@ public class SQLiteLocalStore extends SQLiteOpenHelper implements MobileServiceL
         return whereClause;
     }
 
-    private void createTableFromObject(String invTableName, Map<String, ColumnDataInfo> table) {
-        SQLiteDatabase db = this.getWritableDatabase();
-
+    private void createTableFromObject(SQLiteDatabase db, String invTableName, Map<String, ColumnDataInfo> table) {
         String tblSql = String.format("CREATE TABLE IF NOT EXISTS \"%s\" (\"id\" TEXT PRIMARY KEY);", invTableName);
         db.execSQL(tblSql);
 
@@ -684,6 +686,22 @@ public class SQLiteLocalStore extends SQLiteOpenHelper implements MobileServiceL
             db.execSQL(createSql);
         }
     }
+	
+	private SQLiteDatabase getWritableDatabaseSynchronized() {
+		synchronized (mConcurrencyLock) {
+			mConcurrencyCount++;
+			return getWritableDatabase();
+		}
+	}
+	
+	private void closeDatabaseSynchronized(SQLiteDatabase db) {
+		synchronized (mConcurrencyLock) {
+			mConcurrencyCount--;
+			if (mConcurrencyCount == 0) {
+				db.close();
+			}
+		}
+	}
 
     private static class Statement {
         private String sql;

--- a/sdk/android/src/sdk/src/main/java/com/microsoft/windowsazure/mobileservices/table/sync/localstore/SQLiteLocalStore.java
+++ b/sdk/android/src/sdk/src/main/java/com/microsoft/windowsazure/mobileservices/table/sync/localstore/SQLiteLocalStore.java
@@ -52,8 +52,8 @@ import java.util.Map.Entry;
  */
 public class SQLiteLocalStore extends SQLiteOpenHelper implements MobileServiceLocalStore {
     private Map<String, Map<String, ColumnDataInfo>> mTables;
-	private int mConcurrencyCount;
-	private Object mConcurrencyLock;
+    private int mConcurrencyCount;
+    private Object mConcurrencyLock;
 
     /**
      * Constructor for SQLiteLocalStore
@@ -70,8 +70,8 @@ public class SQLiteLocalStore extends SQLiteOpenHelper implements MobileServiceL
     public SQLiteLocalStore(Context context, String name, CursorFactory factory, int version) {
         super(context, name, factory, version);
         this.mTables = new HashMap<String, Map<String, ColumnDataInfo>>();
-		this.mConcurrencyCount = 0;
-		this.mConcurrencyLock = new Object();
+        this.mConcurrencyCount = 0;
+        this.mConcurrencyLock = new Object();
     }
 
     /**
@@ -96,7 +96,7 @@ public class SQLiteLocalStore extends SQLiteOpenHelper implements MobileServiceL
 
     @Override
     public void initialize() throws MobileServiceLocalStoreException {
-		SQLiteDatabase db = this.getWritableDatabaseSynchronized();
+        SQLiteDatabase db = this.getWritableDatabaseSynchronized();
         try {
             for (Entry<String, Map<String, ColumnDataInfo>> entry : this.mTables.entrySet()) {
                 createTableFromObject(db, entry.getKey(), entry.getValue());
@@ -104,8 +104,8 @@ public class SQLiteLocalStore extends SQLiteOpenHelper implements MobileServiceL
         } catch (Throwable t) {
             throw new MobileServiceLocalStoreException(t);
         } finally {
-			this.closeDatabaseSynchronized(db);
-		}
+            this.closeDatabaseSynchronized(db);
+        }
     }
 
     @Override
@@ -153,7 +153,7 @@ public class SQLiteLocalStore extends SQLiteOpenHelper implements MobileServiceL
 
             Integer inlineCount = null;
 
-			SQLiteDatabase db = this.getWritableDatabaseSynchronized();
+            SQLiteDatabase db = this.getWritableDatabaseSynchronized();
 
             try {
                 Cursor cursor = null;
@@ -184,7 +184,7 @@ public class SQLiteLocalStore extends SQLiteOpenHelper implements MobileServiceL
                     }
                 }
             } finally {
-				this.closeDatabaseSynchronized(db);
+                this.closeDatabaseSynchronized(db);
             }
 
             if (query.hasInlineCount()) {
@@ -211,7 +211,7 @@ public class SQLiteLocalStore extends SQLiteOpenHelper implements MobileServiceL
             Map<String, ColumnDataInfo> table = this.mTables.get(invTableName);
 
             SQLiteDatabase db = this.getWritableDatabaseSynchronized();
-			
+            
             try {
                 Cursor cursor = null;
 
@@ -686,22 +686,22 @@ public class SQLiteLocalStore extends SQLiteOpenHelper implements MobileServiceL
             db.execSQL(createSql);
         }
     }
-	
-	private SQLiteDatabase getWritableDatabaseSynchronized() {
-		synchronized (mConcurrencyLock) {
-			mConcurrencyCount++;
-			return getWritableDatabase();
-		}
-	}
-	
-	private void closeDatabaseSynchronized(SQLiteDatabase db) {
-		synchronized (mConcurrencyLock) {
-			mConcurrencyCount--;
-			if (mConcurrencyCount == 0) {
-				db.close();
-			}
-		}
-	}
+    
+    private SQLiteDatabase getWritableDatabaseSynchronized() {
+        synchronized (mConcurrencyLock) {
+            mConcurrencyCount++;
+            return getWritableDatabase();
+        }
+    }
+    
+    private void closeDatabaseSynchronized(SQLiteDatabase db) {
+        synchronized (mConcurrencyLock) {
+            mConcurrencyCount--;
+            if (mConcurrencyCount == 0) {
+                db.close();
+            }
+        }
+    }
 
     private static class Statement {
         private String sql;

--- a/sdk/android/test/sdk.testapp/src/main/java/com/microsoft/windowsazure/mobileservices/sdk/testapp/test/SQLiteStoreTests.java
+++ b/sdk/android/test/sdk.testapp/src/main/java/com/microsoft/windowsazure/mobileservices/sdk/testapp/test/SQLiteStoreTests.java
@@ -466,67 +466,67 @@ public class SQLiteStoreTests extends InstrumentationTestCase {
         long count = SQLiteStoreTestsUtilities.countRows(this.getContext(), TestDbName, TestTable);
         assertEquals(count, 1L);
     }
-	
-	private class OffThreadInsert implements Runnable {
-		private SQLiteLocalStore mStore;
-		private String mObjectId;
-		private CountDownLatch mBlocker;
-		private boolean mSuccess;
-		
-		public OffThreadInsert(CountDownLatch blocker, SQLiteLocalStore store, String objectId) {
-			mStore = store;
-			mObjectId = objectId;
-			mBlocker = blocker;
-			mSuccess = false;
-		}
-		
-		@Override
-		public void run() {
-			try {
-				JsonObject inserted = new JsonObject();
-				inserted.addProperty("id", mObjectId);
-				inserted.addProperty("__createdAt", new Date().toString());
-			
-				mBlocker.await();
-				mStore.upsert(TestTable, inserted, false);
-				mSuccess = true;
-			} catch (Throwable t) {
-				mSuccess = false;
-			}
-		}
-		
-		public boolean succeeded() {
-			return mSuccess;
-		}
-	}
-	
-	public void testSimultaneousOperations() throws MobileServiceLocalStoreException, InterruptedException {
-		prepareTodoTable();
-		SQLiteLocalStore store = new SQLiteLocalStore(this.getContext(), TestDbName, null, 1);
-		
-		defineTestTable(store);
+    
+    private class OffThreadInsert implements Runnable {
+        private SQLiteLocalStore mStore;
+        private String mObjectId;
+        private CountDownLatch mBlocker;
+        private boolean mSuccess;
+        
+        public OffThreadInsert(CountDownLatch blocker, SQLiteLocalStore store, String objectId) {
+            mStore = store;
+            mObjectId = objectId;
+            mBlocker = blocker;
+            mSuccess = false;
+        }
+        
+        @Override
+        public void run() {
+            try {
+                JsonObject inserted = new JsonObject();
+                inserted.addProperty("id", mObjectId);
+                inserted.addProperty("__createdAt", new Date().toString());
+            
+                mBlocker.await();
+                mStore.upsert(TestTable, inserted, false);
+                mSuccess = true;
+            } catch (Throwable t) {
+                mSuccess = false;
+            }
+        }
+        
+        public boolean succeeded() {
+            return mSuccess;
+        }
+    }
+    
+    public void testSimultaneousOperations() throws MobileServiceLocalStoreException, InterruptedException {
+        prepareTodoTable();
+        SQLiteLocalStore store = new SQLiteLocalStore(this.getContext(), TestDbName, null, 1);
+        
+        defineTestTable(store);
         store.initialize();
-		
-		CountDownLatch threadBlocker = new CountDownLatch(1);
-		Thread[] threads = new Thread[5];
-		OffThreadInsert[] runnables = new OffThreadInsert[5];
-		
-		for (int i = 0; i < threads.length; i++) {
-			runnables[i] = new OffThreadInsert(threadBlocker, store, "object"+i);
-			threads[i] = new Thread(runnables[i]);
-			threads[i].start();
-		}
-		
-		threadBlocker.countDown();
-		
-		for (int i = 0; i < threads.length; i++) {
-			threads[i].join();
-			assertTrue(runnables[i].succeeded());
-		}
-		
-		long count = SQLiteStoreTestsUtilities.countRows(this.getContext(), TestDbName, TestTable);
+        
+        CountDownLatch threadBlocker = new CountDownLatch(1);
+        Thread[] threads = new Thread[5];
+        OffThreadInsert[] runnables = new OffThreadInsert[5];
+        
+        for (int i = 0; i < threads.length; i++) {
+            runnables[i] = new OffThreadInsert(threadBlocker, store, "object"+i);
+            threads[i] = new Thread(runnables[i]);
+            threads[i].start();
+        }
+        
+        threadBlocker.countDown();
+        
+        for (int i = 0; i < threads.length; i++) {
+            threads[i].join();
+            assertTrue(runnables[i].succeeded());
+        }
+        
+        long count = SQLiteStoreTestsUtilities.countRows(this.getContext(), TestDbName, TestTable);
         assertEquals(count, (long)threads.length);
-	}
+    }
 
     public void testUpsertThenLookupThenUpsertThenDeleteThenLookup() throws MobileServiceLocalStoreException {
         SQLiteStoreTestsUtilities.dropTestTable(this.getContext(), TestDbName, TestTable);


### PR DESCRIPTION
This fixes issue #622. It does so by implementing a count of concurrent users of the database, and the last user closes the database. This way we maintain the behavior of allowing multiple threads to access the database at the same time, while preventing threads from closing the database out from under each other.

The unit test fails before this, and passes after.