### PR TITLE
Fix a large part of the problem described in Issue #615. This is a subse...

### DIFF
--- a/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/Table/Sync/Queue/Actions/PushAction.cs
+++ b/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/Table/Sync/Queue/Actions/PushAction.cs
@@ -132,104 +132,104 @@ namespace Microsoft.WindowsAzure.MobileServices.Sync
             // keep taking out operations and executing them until queue is empty or operation finds the bookmark or batch is aborted 
             while (operation != null)
             {
-                bool success = await this.ExecuteOperationAsync(operation, batch);
-
-                if (batch.AbortReason.HasValue)
+                using (await this.OperationQueue.LockItemAsync(operation.ItemId, this.CancellationToken))
                 {
-                    break;
-                }
+                    bool success = await this.ExecuteOperationAsync(operation, batch);
 
-                if (success)
-                {
-                    // we successfuly executed an operation so remove it from queue
-                    await this.OperationQueue.DeleteAsync(operation.Id, operation.Version);
-                }
+                    if (batch.AbortReason.HasValue)
+                    {
+                        break;
+                    }
 
-                // get next operation
-                operation = await this.OperationQueue.PeekAsync(operation.Sequence, this.tableKind, this.tableNames);
+                    if (success)
+                    {
+                        // we successfuly executed an operation so remove it from queue
+                        await this.OperationQueue.DeleteAsync(operation.Id, operation.Version);
+                    }
+
+                    // get next operation
+                    operation = await this.OperationQueue.PeekAsync(operation.Sequence, this.tableKind, this.tableNames);
+                }
             }
         }
 
         private async Task<bool> ExecuteOperationAsync(MobileServiceTableOperation operation, OperationBatch batch)
         {
-            using (await this.OperationQueue.LockItemAsync(operation.ItemId, this.CancellationToken))
+            if (operation.IsCancelled || this.CancellationToken.IsCancellationRequested)
             {
-                if (operation.IsCancelled || this.CancellationToken.IsCancellationRequested)
-                {
-                    return false;
-                }
-
-                operation.Table = await this.context.GetTable(operation.TableName);
-                await this.LoadOperationItem(operation, batch);
-
-                if (this.CancellationToken.IsCancellationRequested)
-                {
-                    return false;
-                }
-
-                await TryUpdateOperationState(operation, MobileServiceTableOperationState.Attempted, batch);
-
-                // strip out system properties before executing the operation
-                operation.Item = MobileServiceSyncTable.RemoveSystemPropertiesKeepVersion(operation.Item);
-
-                JObject result = null;
-                Exception error = null;
-                try
-                {
-                    result = await batch.SyncHandler.ExecuteTableOperationAsync(operation);
-                }
-                catch (Exception ex)
-                {
-                    error = ex;
-                }
-
-                if (error != null)
-                {
-                    await TryUpdateOperationState(operation, MobileServiceTableOperationState.Failed, batch);
-
-                    if (TryAbortBatch(batch, error))
-                    {
-                        // there is no error to save in sync error and no result to capture
-                        // this operation will be executed again next time the push happens
-                        return false;
-                    }
-                }
-
-                // save the result if ExecuteTableOperation did not throw
-                if (error == null && result.IsValidItem() && operation.CanWriteResultToStore)
-                {
-                    await TryStoreOperation(() => this.Store.UpsertAsync(operation.TableName, result, fromServer: true), batch, Resources.SyncStore_FailedToUpsertItem);
-                }
-                else if (error != null)
-                {
-                    HttpStatusCode? statusCode = null;
-                    string rawResult = null;
-                    var iox = error as MobileServiceInvalidOperationException;
-                    if (iox != null && iox.Response != null)
-                    {
-                        statusCode = iox.Response.StatusCode;
-                        Tuple<string, JToken> content = await MobileServiceTable.ParseContent(iox.Response, this.client.SerializerSettings);
-                        rawResult = content.Item1;
-                        result = content.Item2.ValidItemOrNull();
-                    }
-                    var syncError = new MobileServiceTableOperationError(operation.Id,
-                                                                         operation.Version,
-                                                                         operation.Kind,
-                                                                         statusCode,
-                                                                         operation.TableName,
-                                                                         operation.Item,
-                                                                         rawResult,
-                                                                         result)
-                                                                         {
-                                                                             TableKind = this.tableKind,
-                                                                             Context = this.context
-                                                                         };
-                    await batch.AddSyncErrorAsync(syncError);
-                }
-
-                bool success = error == null;
-                return success;
+                return false;
             }
+
+            operation.Table = await this.context.GetTable(operation.TableName);
+            await this.LoadOperationItem(operation, batch);
+
+            if (this.CancellationToken.IsCancellationRequested)
+            {
+                return false;
+            }
+
+            await TryUpdateOperationState(operation, MobileServiceTableOperationState.Attempted, batch);
+
+            // strip out system properties before executing the operation
+            operation.Item = MobileServiceSyncTable.RemoveSystemPropertiesKeepVersion(operation.Item);
+
+            JObject result = null;
+            Exception error = null;
+            try
+            {
+                result = await batch.SyncHandler.ExecuteTableOperationAsync(operation);
+            }
+            catch (Exception ex)
+            {
+                error = ex;
+            }
+
+            if (error != null)
+            {
+                await TryUpdateOperationState(operation, MobileServiceTableOperationState.Failed, batch);
+
+                if (TryAbortBatch(batch, error))
+                {
+                    // there is no error to save in sync error and no result to capture
+                    // this operation will be executed again next time the push happens
+                    return false;
+                }
+            }
+
+            // save the result if ExecuteTableOperation did not throw
+            if (error == null && result.IsValidItem() && operation.CanWriteResultToStore)
+            {
+                await TryStoreOperation(() => this.Store.UpsertAsync(operation.TableName, result, fromServer: true), batch, Resources.SyncStore_FailedToUpsertItem);
+            }
+            else if (error != null)
+            {
+                HttpStatusCode? statusCode = null;
+                string rawResult = null;
+                var iox = error as MobileServiceInvalidOperationException;
+                if (iox != null && iox.Response != null)
+                {
+                    statusCode = iox.Response.StatusCode;
+                    Tuple<string, JToken> content = await MobileServiceTable.ParseContent(iox.Response, this.client.SerializerSettings);
+                    rawResult = content.Item1;
+                    result = content.Item2.ValidItemOrNull();
+                }
+                var syncError = new MobileServiceTableOperationError(operation.Id,
+                                                                        operation.Version,
+                                                                        operation.Kind,
+                                                                        statusCode,
+                                                                        operation.TableName,
+                                                                        operation.Item,
+                                                                        rawResult,
+                                                                        result)
+                                                                        {
+                                                                            TableKind = this.tableKind,
+                                                                            Context = this.context
+                                                                        };
+                await batch.AddSyncErrorAsync(syncError);
+            }
+
+            bool success = error == null;
+            return success;
         }
 
         private async Task TryUpdateOperationState(MobileServiceTableOperation operation, MobileServiceTableOperationState state, OperationBatch batch)

--- a/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.Test/Mocks/MobileServiceLocalStoreMock.cs
+++ b/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.Test/Mocks/MobileServiceLocalStoreMock.cs
@@ -120,7 +120,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             return Task.FromResult(0);
         }
 
-        public Task<JObject> LookupAsync(string tableName, string id)
+        public virtual Task<JObject> LookupAsync(string tableName, string id)
         {
             MockTable table = GetTable(tableName);
             JObject item;

--- a/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.Test/UnitTests/Table/Sync/MobileServiceSyncContext.Test.cs
+++ b/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.Test/UnitTests/Table/Sync/MobileServiceSyncContext.Test.cs
@@ -246,6 +246,136 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             await service.SyncContext.PushAsync();
         }
 
+        class LocalStoreWithDelay : MobileServiceLocalStoreMock
+        {
+            private int _lookupDelayInMilliseconds = 0;
+
+            public override async Task<JObject> LookupAsync(string tableName, string id)
+            {
+                if (0 != _lookupDelayInMilliseconds)
+                {
+                    // releases this thread and causes this lookup to take longer
+                    await Task.Delay(_lookupDelayInMilliseconds);
+                }
+
+                return await base.LookupAsync(tableName, id);
+            }
+
+            /// <summary>
+            /// Tells this mock to yield and to delay for the given number of milliseconds before proceeding with the LookupAsync().
+            /// </summary>
+            /// <param name="delayInMilliseconds">The delay in milliseconds.</param>
+            internal void SetLookupDelay(int delayInMilliseconds)
+            {
+                _lookupDelayInMilliseconds = delayInMilliseconds;
+            }
+        }
+
+        [AsyncTestMethod]
+        public async Task PushAsync_Succeeds_WithPendingOperations_AndOpQueueIsConsistent()
+        {
+            // Essentially async ManualResetEvents
+            SemaphoreSlim untilPendingOpsCreated = new SemaphoreSlim(0, 1);
+            SemaphoreSlim untilAboutToExecuteOp = new SemaphoreSlim(0, 1);
+
+            int pushState = 0;
+
+            var handler = new MobileServiceSyncHandlerMock();
+
+            handler.TableOperationAction = async op =>
+            {
+                try
+                {
+                    untilAboutToExecuteOp.Release();
+                    await untilPendingOpsCreated.WaitAsync();
+
+                    JObject result = await op.ExecuteAsync();
+
+                    if (0 == pushState)
+                    {
+                        Assert.AreEqual(MobileServiceTableOperationKind.Insert, op.Kind);
+                        Assert.AreEqual(0, op.Item.Value<int>("value"));
+                    }
+                    else
+                    {
+                        Assert.AreEqual(MobileServiceTableOperationKind.Update, op.Kind);
+                        Assert.AreEqual(2, op.Item.Value<int>("value")); // We shouldn't see the value == 1, since it should have been collapsed
+                    }
+
+                    // We don't care what the server actually returned, as long as there was no exception raised in our Push logic
+                    return result;
+                }
+                catch (Exception ex)
+                {
+                    Assert.Fail("Things are bad: " + ex.Message);
+                }
+
+                return null;
+            };
+
+            var hijack = new TestHttpHandler();
+
+            IMobileServiceClient service = new MobileServiceClient("http://www.test.com", "secret...", hijack);
+            LocalStoreWithDelay mockLocalStore = new LocalStoreWithDelay();
+            await service.SyncContext.InitializeAsync(mockLocalStore, handler);
+
+            JObject item = null;
+
+            // Add the initial operation and perform a push
+            IMobileServiceSyncTable table = service.GetSyncTable("someTable");
+
+            string responseContent = @"{ ""id"": ""abc"", ""value"": ""0"", ""__version"": ""v0"" }"; // Whatever is fine, since we won't use it or look at it
+
+            // Do this Insert/Push/Update+Update/Push cycle several times fast to try to hit any race conditions that would cause an error
+            for (int id = 0; id < 10; id++)
+            {
+                hijack.SetResponseContent(responseContent);
+                string idStr = "id" + id; // Generate a new Id each time in case the mock objects ever care that we insert an item that already exists
+
+                // The Operations and PushAction don't necessarily clone the JObject, so we need a fresh one for each operation or else we'll change
+                // the in-memory representation of the JObject stored in all operations, as well as in the "batch" the PushAction owns. This is problematic.
+                item = new JObject() { { "id", idStr }, { "value", 0 } };
+                await table.InsertAsync(item);
+
+                Task pushComplete = service.SyncContext.PushAsync();
+
+                // Make sure the PushAction has actually called into our SyncHandler, otherwise the two UpdateOperations could collapse onto it, and
+                // there won't necessarily even be a second PushAction
+                await untilAboutToExecuteOp.WaitAsync();
+
+                // Add some more operations while that push is in flight. Since these operations affect the same item in someTable, the operations
+                // will be stuck awaiting the PushAction since it locks on the row.
+                item = new JObject() { { "id", idStr }, { "value", 1 } };
+                Task updateOnce = table.UpdateAsync(item);
+
+                item = new JObject() { { "id", idStr }, { "value", 2 } };
+                Task updateTwice = table.UpdateAsync(item);
+
+                // Before we let the push finish, let's inject a delay that will cause it to take a long time deleting the operation from the queue.
+                // This will give the other operations, if there's an unaddressed race condition, a chance to wreak havoc on the op queue.
+                mockLocalStore.SetLookupDelay(500);
+
+                // Let the first push finish
+                untilPendingOpsCreated.Release();
+                await pushComplete;
+
+                mockLocalStore.SetLookupDelay(0);
+
+                await updateOnce;
+                await updateTwice;
+
+                // Push again, but now the operation condensed from the two updates should be executed remotely
+                pushState = (pushState + 1) % 2;
+                hijack.SetResponseContent(responseContent);
+                pushComplete = service.SyncContext.PushAsync();
+                await untilAboutToExecuteOp.WaitAsync(); // not strictly necessary other than to keep the semaphore count at 0
+                untilPendingOpsCreated.Release();
+
+                await pushComplete;
+                pushState = (pushState + 1) % 2;
+            }
+        }
+
         [AsyncTestMethod]
         public async Task CancelAndUpdateItemAsync_UpsertsTheItemInLocalStore_AndDeletesTheOperationAndError()
         {


### PR DESCRIPTION
...t of Pull Request #614 with just the subset I think can be merged as per the conversation with @phvannor.

This moves the lock out to protect the calls to DeleteAsync() and PeekAsync() on the OperationQueue, which prevents a lot of the badness described in Issue #615. There are still deeper issues around versioning of the actual items in the local store, but that's another discussion. All unit tests pass on WP8, WP81 and Win8. 

I'm requesting this be pulled into the 'dev' branch as per the comment from @phvannor on Pull Request #614.