### PR TITLE
[iOS] NSManagedObjectContext save observer

### DIFF
--- a/sdk/iOS/src/MSClient.m
+++ b/sdk/iOS/src/MSClient.m
@@ -275,6 +275,8 @@
                                                                             
     client.currentUser = [self.currentUser copyWithZone:zone];
     client.filters = [self.filters copyWithZone:zone];
+	
+	client.syncContext = [[MSSyncContext alloc] initWithDelegate:self.syncContext.delegate dataSource:self.syncContext.dataSource callback:self.syncContext.callbackQueue];
 
     return client;
 }

--- a/sdk/iOS/src/MSCoreDataStore.h
+++ b/sdk/iOS/src/MSCoreDataStore.h
@@ -6,6 +6,8 @@
 #import <WindowsAzureMobileServices/WindowsAzureMobileServices.h>
 #import <CoreData/CoreData.h>
 
+extern NSString *const StoreVersion;
+
 /// The MSCoreDataStore class is for use when using the offline capabilities
 /// of mobile services. This class is a local store which manages records and sync
 /// logic using CoreData.
@@ -14,6 +16,9 @@
 /// MS_TableOperationErrors: Columns: id (string), properties (binary data)
 /// and all tables contain a ms_version column
 @interface MSCoreDataStore : NSObject <MSSyncContextDataSource>
+
+/// The NSManagedObjectContext that is associated with this data store
+@property (readonly, nonatomic, strong) NSManagedObjectContext *context;
 
 /// Disables the store from recieving information about the items passed into all sync table
 /// calls (insert, delete, update). If set, the application is responsible for already having

--- a/sdk/iOS/src/MSManagedObjectObserver.h
+++ b/sdk/iOS/src/MSManagedObjectObserver.h
@@ -7,12 +7,11 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "MSClient.h"
+
+@class MSClient;
 
 @interface MSManagedObjectObserver : NSObject
 
-- (id) initWithClient:(MSClient *)client;
-
-- (id) initWithClient:(MSClient *)client contextsToObserver:(NSArray *)contexts;
+- (instancetype) initWithClient:(MSClient *)client;
 
 @end

--- a/sdk/iOS/src/MSManagedObjectObserver.m
+++ b/sdk/iOS/src/MSManagedObjectObserver.m
@@ -7,35 +7,115 @@
 //
 
 #import "MSManagedObjectObserver.h"
+#import "MSCoreDataStore.h"
+#import "MSClient.h"
 #import <CoreData/CoreData.h>
 
 @interface MSManagedObjectObserver()
-@property (nonatomic, weak) MSClient *client;
+@property (nonatomic, strong) MSClient *client;
+@property (nonatomic, weak) NSManagedObjectContext *context;
 @end
 
 @implementation MSManagedObjectObserver
 
-- (id) initWithClient:(MSClient *)client
-{
-    return [self initWithClient:client contextsToObserver:nil];
-}
-
-- (id) initWithClient:(MSClient *)client contextsToObserver:(NSArray *)contexts
+- (instancetype) initWithClient:(MSClient *)client
 {
     self = [super init];
     if (self) {
-        _client = client;
+		// Copy so we can change the handling of how the sync table operations are handled
+        _client = [client copy];
+		
+		if ([_client.syncContext.dataSource isKindOfClass:[MSCoreDataStore class]])
+		{
+			MSCoreDataStore *dataStore = _client.syncContext.dataSource;
+			_context = dataStore.context;
+			
+			[[NSNotificationCenter defaultCenter] addObserver:self
+													 selector:@selector(handleDidSaveNotification:)
+														 name:NSManagedObjectContextDidSaveNotification
+													   object:_context];
+		}
+		
+		// Modify the handling of sync table operations for this instance of the data source
+		_client.syncContext.dataSource.handlesSyncTableOperations = FALSE;
     }
     return self;
 }
 
-- (void) registerAsObserver
+- (void)dealloc
 {
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleDidSaveNotification:)
-                                                 name:NSManagedObjectContextDidSaveNotification
-                                               object:nil];
+	if (self.context != nil)
+	{
+		[[NSNotificationCenter defaultCenter] removeObserver:self
+														name:NSManagedObjectContextDidSaveNotification
+													  object:self.context];
+	}
+}
 
+- (void)handleDidSaveNotification:(NSNotification *)notification
+{
+	NSSet *insertedObjects = notification.userInfo[NSInsertedObjectsKey];
+	for (NSManagedObject *insertedObject in insertedObjects)
+	{
+		if (insertedObject.entity.attributesByName[StoreVersion] == nil) {
+			// Only apply table operations on entities we expect to be managed by the mobile service
+			continue;
+		}
+		
+		NSString *tableName = insertedObject.entity.name;
+		NSDictionary *tableItem = [MSCoreDataStore tableItemFromManagedObject:insertedObject];
+		
+		MSSyncTable *syncTable = [self.client syncTableWithName:tableName];
+		[syncTable insert:tableItem completion:^(NSDictionary *item, NSError *error) {
+			if (error != nil) {
+				NSLog(@"Error inserting %@ into %@ table with error: %@", tableItem, tableName, error);
+			} else {
+				NSLog(@"Successfully inserted %@ into %@", tableItem, tableName);
+			}
+		}];
+	}
+	
+	NSSet *updatedObjects = notification.userInfo[NSInsertedObjectsKey];
+	for (NSManagedObject *updatedObject in updatedObjects)
+	{
+		if (updatedObject.entity.attributesByName[StoreVersion] == nil) {
+			// Only apply table operations on entities we expect to be managed by the mobile service
+			continue;
+		}
+		
+		NSString *tableName = updatedObject.entity.name;
+		NSDictionary *tableItem = [MSCoreDataStore tableItemFromManagedObject:updatedObject];
+		
+		MSSyncTable *syncTable = [self.client syncTableWithName:tableName];
+		[syncTable update:tableItem completion:^(NSError *error) {
+			if (error != nil) {
+				NSLog(@"Error updating %@ into %@ table with error: %@", tableItem, tableName, error);
+			}else {
+				NSLog(@"Successfully updated %@ into %@", tableItem, tableName);
+			}
+		}];
+	}
+	
+	NSSet *deletedObjects = notification.userInfo[NSInsertedObjectsKey];
+	for (NSManagedObject *deletedObject in deletedObjects)
+	{
+		if (deletedObject.entity.attributesByName[StoreVersion] == nil) {
+			// Only apply table operations on entities we expect to be managed by the mobile service
+			continue;
+		}
+		
+		NSString *tableName = deletedObject.entity.name;
+		NSDictionary *tableItem = [MSCoreDataStore tableItemFromManagedObject:deletedObject];
+		
+		MSSyncTable *syncTable = [self.client syncTableWithName:tableName];
+		[syncTable delete:tableItem completion:^(NSError *error) {
+			if (error != nil) {
+				NSLog(@"Error deleting %@ from %@ table with error: %@", tableItem, tableName, error);
+			}else {
+				NSLog(@"Successfully deleted %@ from %@", tableItem, tableName);
+			}
+		}];
+	}
 }
 
 @end

--- a/sdk/iOS/src/MSManagedObjectObserver.m
+++ b/sdk/iOS/src/MSManagedObjectObserver.m
@@ -64,7 +64,7 @@
 	NSSet *insertedObjects = notification.userInfo[NSInsertedObjectsKey];
 	for (NSManagedObject *insertedObject in insertedObjects)
 	{
-		if ([self entityHasRemoteStoreAttributes:insertedObject] == FALSE) {
+		if (![self entityHasRemoteStoreAttributes:insertedObject]) {
 			// Only apply table operations on entities we expect to be managed by the mobile service
 			continue;
 		}
@@ -85,7 +85,7 @@
 	NSSet *updatedObjects = notification.userInfo[NSUpdatedObjectsKey];
 	for (NSManagedObject *updatedObject in updatedObjects)
 	{
-		if ([self entityHasRemoteStoreAttributes:updatedObject] == FALSE) {
+		if (![self entityHasRemoteStoreAttributes:updatedObject]) {
 			// Only apply table operations on entities we expect to be managed by the mobile service
 			continue;
 		}
@@ -106,7 +106,7 @@
 	NSSet *deletedObjects = notification.userInfo[NSDeletedObjectsKey];
 	for (NSManagedObject *deletedObject in deletedObjects)
 	{
-		if ([self entityHasRemoteStoreAttributes:deletedObject] == FALSE) {
+		if (![self entityHasRemoteStoreAttributes:deletedObject]) {
 			// Only apply table operations on entities we expect to be managed by the mobile service
 			continue;
 		}

--- a/sdk/iOS/src/MSManagedObjectObserver.m
+++ b/sdk/iOS/src/MSManagedObjectObserver.m
@@ -52,12 +52,19 @@
 	}
 }
 
+/// Checks the entity has the ms_version attribute to signal it should
+/// be synchronised to the mobile service
+- (BOOL)entityHasRemoteStoreAttributes:(NSManagedObject *)managedObject
+{
+	return (managedObject.entity.attributesByName[StoreVersion] != nil);
+}
+
 - (void)handleDidSaveNotification:(NSNotification *)notification
 {
 	NSSet *insertedObjects = notification.userInfo[NSInsertedObjectsKey];
 	for (NSManagedObject *insertedObject in insertedObjects)
 	{
-		if (insertedObject.entity.attributesByName[StoreVersion] == nil) {
+		if ([self entityHasRemoteStoreAttributes:insertedObject] == FALSE) {
 			// Only apply table operations on entities we expect to be managed by the mobile service
 			continue;
 		}
@@ -75,10 +82,10 @@
 		}];
 	}
 	
-	NSSet *updatedObjects = notification.userInfo[NSInsertedObjectsKey];
+	NSSet *updatedObjects = notification.userInfo[NSUpdatedObjectsKey];
 	for (NSManagedObject *updatedObject in updatedObjects)
 	{
-		if (updatedObject.entity.attributesByName[StoreVersion] == nil) {
+		if ([self entityHasRemoteStoreAttributes:updatedObject] == FALSE) {
 			// Only apply table operations on entities we expect to be managed by the mobile service
 			continue;
 		}
@@ -96,10 +103,10 @@
 		}];
 	}
 	
-	NSSet *deletedObjects = notification.userInfo[NSInsertedObjectsKey];
+	NSSet *deletedObjects = notification.userInfo[NSDeletedObjectsKey];
 	for (NSManagedObject *deletedObject in deletedObjects)
 	{
-		if (deletedObject.entity.attributesByName[StoreVersion] == nil) {
+		if ([self entityHasRemoteStoreAttributes:deletedObject] == FALSE) {
 			// Only apply table operations on entities we expect to be managed by the mobile service
 			continue;
 		}

--- a/sdk/iOS/src/MSSyncContext.h
+++ b/sdk/iOS/src/MSSyncContext.h
@@ -58,7 +58,7 @@ typedef void (^MSSyncPushCompletionBlock)(void);
 
 /// Indicates if the items passed to a sync table call should be saved by the SDK, if disabled, the local store will only
 /// recieve upserts/deletes for data calls originating from the server (pulls & pushes) plus the state tracking on the operation queue.
-- (BOOL) handlesSyncTableOperations;
+@property (nonatomic) BOOL handlesSyncTableOperations;
 
 /// @}
 

--- a/sdk/iOS/src/WindowsAzureMobileServices.h
+++ b/sdk/iOS/src/WindowsAzureMobileServices.h
@@ -19,6 +19,7 @@
 #import "MSCoreDataStore.h"
 #import "MSPush.h"
 #import "MSDateOffset.h"
+#import "MSManagedObjectObserver.h"
 
 #define WindowsAzureMobileServicesSdkMajorVersion 2
 #define WindowsAzureMobileServicesSdkMinorVersion 0


### PR DESCRIPTION
Context observer for automatic message creation for entities saved with an NSManagedObjectContext. Also prevents the MSCoreDataStore from trying to re-insert/update/delete the entity and just creates the server message as discussed in issue #568 