### PR TITLE
Fix scenario of single wired up delegating handler

### DIFF
--- a/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/Http/MobileServiceHttpClient.cs
+++ b/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/Http/MobileServiceHttpClient.cs
@@ -625,7 +625,7 @@ namespace Microsoft.WindowsAzure.MobileServices
         {
             HttpMessageHandler pipeline = handlers.LastOrDefault() ?? DefaultHandlerFactory();
             DelegatingHandler dHandler = pipeline as DelegatingHandler;
-            if (dHandler != null)
+            if (dHandler != null && dHandler.InnerHandler == null)
             {
                 dHandler.InnerHandler = DefaultHandlerFactory();
                 pipeline = dHandler;

--- a/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.Test/UnitTests/MobileServiceClient.Test.cs
+++ b/sdk/Managed/test/Microsoft.WindowsAzure.MobileServices.Test/UnitTests/MobileServiceClient.Test.cs
@@ -107,6 +107,21 @@ namespace Microsoft.WindowsAzure.MobileServices.Test
             Assert.StartsWith(hijack.Request.RequestUri.ToString(), mobileAppUriValidator.TableBaseUri);
         }
 
+        [TestMethod]
+        public void DoesNotRewireSingleWiredDelegatingHandler()
+        {
+            string appUrl = MobileAppUriValidator.DummyMobileApp;
+            string appKey = "secret...";
+
+            TestHttpHandler innerHandler = new TestHttpHandler();
+            DelegatingHandler wiredHandler = new TestHttpHandler();
+            wiredHandler.InnerHandler = innerHandler;
+
+            IMobileServiceClient service = new MobileServiceClient(appUrl, applicationKey: appKey, handlers: wiredHandler);
+
+            Assert.AreEqual(wiredHandler.InnerHandler, innerHandler, "The prewired handler passed in should not have been rewired");
+        }
+
         [AsyncTestMethod]
         public async Task MultipleHttpHandlerConstructor()
         {


### PR DESCRIPTION
The MobileServiceClient constructor will rewire any delegating handlers passed in. This makes it difficult to do advanced handler stack scenarios.