### PR TITLE
iOS: Fix cancelAndUpdate/Discard Functions

### DIFF
--- a/CHANGELOG.ios.md
+++ b/CHANGELOG.ios.md
@@ -4,10 +4,13 @@
 - [iOS 2.0 SDK](http://aka.ms/gc6fex)
 - [iOS 1.2.4 SDK](http://aka.ms/kymw2g)
 
-### iOS SDK: Version 2.0
+### Version 2.1.0
+- Fix cancelAndUpdate and cancelAndDiscard actions on the MSTableOperationError class
+
+### Version 2.0.0
 - GA of offline sync changes from previous betas
 
-### iOS SDK: Version 2.0.0 beta2
+### Version 2.0.0 beta2
 - **[Breaking]** Changed MSReadQueryBlock to return MSQueryResult instead of items and totalCount. See [this blog post](http://azure.microsoft.com/blog/2014/10/07/mobile-services-beta-ios-sdk-released/) for more information.
 - Added support for incremental sync
 - Added support for query parameters in pull operations
@@ -17,7 +20,7 @@
 - Added a helper method to return an NSDictionary from an NSManagedObject
 - Fixed issue with the __includeDeleted flag sending the wrong value
 
-### iOS SDK: Version 2.0.0 beta1
+### Version 2.0.0 beta1
 
 - Added support for incremental sync
 - Added support for query parameters in pull operations
@@ -26,37 +29,37 @@
 - Added a helper method to return an NSDictionary from an NSManagedObject
 - Fixed issue with the __includeDeleted flag sending the wrong value
 
-### iOS SDK: Version 1.3 alpha1
+### Version 1.3 alpha1
 - Added support for offline and sync
 
-### iOS SDK: Version 1.2.4
+### Version 1.2.4
 - Address bug where version property was returned to the caller even when not asked for
 - Fixes Swift QS for syntax changes up to Xcode Beta 7
 
-### iOS SDK: Version 1.2.3
+### Version 1.2.3
 - Fix issue with const when using both Azure Messaging and Mobile Services frameworks
 - Fix issue [#306](https://github.com/Azure/azure-mobile-services/issues/306) with how arrays passed as query string params to table and custom APIs are converted 
 - Fix issue where system properties (__version, __updatedAt, etc) were returned to the caller when they were not requested
 
-### iOS SDK: Version 1.2.2
+### Version 1.2.2
 - Added support for APNS Azure Notification Hub integration
 - Support for optimistic concurrency on delete
 
 ### iOS SDK
 - - Fix issue [#218](https://github.com/WindowsAzure/azure-mobile-services/issues/218) in which some dates coming from the mobile services with the .NET runtime weren't parsed correctly
 
-### iOS SDK: Version 1.1.3
+### Version 1.1.3
 - Added a mapping in the authentication provider from WindowsAzureActiveDirectory to the value used in the REST API (`/login/aad`)
 
-### iOS SDK: Version 1.1.2
+### Version 1.1.2
 - Supports the arm64 architecture
 - Now requires iOS 6 or newer to use 
 
-### iOS SDK: Version 1.1.1
+### Version 1.1.1
 - Support for optimistic concurrency (version / ETag) validation
 - Support for `__createdAt` / `__updatedAt` table columns
 - Fix bug with using arrays in invokeAPI
 
-### iOS SDK: Version 1.1.0
+### Version 1.1.0
 - Support for tables with string ids
 

--- a/sdk/iOS/WindowsAzureMobileServices.xcodeproj/project.pbxproj
+++ b/sdk/iOS/WindowsAzureMobileServices.xcodeproj/project.pbxproj
@@ -29,8 +29,8 @@
 		870C0C9D199C246700A134DD /* MSSDKFeatures.m in Sources */ = {isa = PBXBuildFile; fileRef = 870C0C9B199C246700A134DD /* MSSDKFeatures.m */; };
 		A214410C182631A500C2E762 /* MSTableFuncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A214410B182631A500C2E762 /* MSTableFuncTests.m */; };
 		A22CF3731825914700660C79 /* MSTable+MSTableTestUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = A22CF3721825914700660C79 /* MSTable+MSTableTestUtilities.m */; };
-		A24425521A67496600854EF9 /* TodoItem.h in Headers */ = {isa = PBXBuildFile; fileRef = A24425501A67496600854EF9 /* TodoItem.h */; };
-		A24425531A67496600854EF9 /* TodoItem.m in Sources */ = {isa = PBXBuildFile; fileRef = A24425511A67496600854EF9 /* TodoItem.m */; };
+		A232CCA21AC8FDE800E15D3A /* MSTableOperationErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A232CCA11AC8FDE800E15D3A /* MSTableOperationErrorTests.m */; };
+		A232CCA31AC9C86D00E15D3A /* TodoItem.m in Sources */ = {isa = PBXBuildFile; fileRef = A24425511A67496600854EF9 /* TodoItem.m */; };
 		A24701B7196896F500385DA2 /* MSLocalStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = A24701AD196896F500385DA2 /* MSLocalStorage.h */; };
 		A24701B8196896F500385DA2 /* MSLocalStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = A24701AE196896F500385DA2 /* MSLocalStorage.m */; };
 		A24701B9196896F500385DA2 /* MSPush.h in Headers */ = {isa = PBXBuildFile; fileRef = A24701AF196896F500385DA2 /* MSPush.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -183,6 +183,7 @@
 		A214410B182631A500C2E762 /* MSTableFuncTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSTableFuncTests.m; sourceTree = "<group>"; };
 		A22CF3711825914700660C79 /* MSTable+MSTableTestUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MSTable+MSTableTestUtilities.h"; sourceTree = "<group>"; };
 		A22CF3721825914700660C79 /* MSTable+MSTableTestUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MSTable+MSTableTestUtilities.m"; sourceTree = "<group>"; };
+		A232CCA11AC8FDE800E15D3A /* MSTableOperationErrorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSTableOperationErrorTests.m; sourceTree = "<group>"; };
 		A24425501A67496600854EF9 /* TodoItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TodoItem.h; sourceTree = "<group>"; };
 		A24425511A67496600854EF9 /* TodoItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TodoItem.m; sourceTree = "<group>"; };
 		A24701AD196896F500385DA2 /* MSLocalStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSLocalStorage.h; sourceTree = "<group>"; };
@@ -428,6 +429,7 @@
 			isa = PBXGroup;
 			children = (
 				A2ADF7E81914481B0078BB16 /* MSTableOperationTests.m */,
+				A232CCA11AC8FDE800E15D3A /* MSTableOperationErrorTests.m */,
 			);
 			name = Operations;
 			sourceTree = "<group>";
@@ -689,7 +691,6 @@
 				A258890B18A19D0B00962F9A /* MSOperationQueue.h in Headers */,
 				CFAE6E0C1A3B84E400734128 /* MSTableConfigValue.h in Headers */,
 				CF1D745B1A5D9CAB0074789F /* MSQueuePurgeOperation.h in Headers */,
-				A24425521A67496600854EF9 /* TodoItem.h in Headers */,
 				E8C44042170BAD49002FC997 /* MSAPIConnection.h in Headers */,
 				A258891518A19D0B00962F9A /* MSSyncContextInternal.h in Headers */,
 				E8C44047170BAD93002FC997 /* MSAPIRequest.h in Headers */,
@@ -870,7 +871,6 @@
 				A24701BC196896F500385DA2 /* MSPushHttp.m in Sources */,
 				E8C44048170BAD93002FC997 /* MSAPIRequest.m in Sources */,
 				CF4D498C1A3253E2006AEB70 /* MSTestWaiter.m in Sources */,
-				A24425531A67496600854EF9 /* TodoItem.m in Sources */,
 				CF1D74591A5D85C60074789F /* MSQueuePurgeOperation.m in Sources */,
 				A2818FFD18BB0660001B14E7 /* MSQueuePushOperation.m in Sources */,
 				A24701B8196896F500385DA2 /* MSLocalStorage.m in Sources */,
@@ -886,6 +886,7 @@
 				A24701CB196897C100385DA2 /* MSMultiRequestTestFilter.m in Sources */,
 				E8F33B3C16166945002DD7C6 /* WindowsAzureMobileServicesFunctionalTests.m in Sources */,
 				A214410C182631A500C2E762 /* MSTableFuncTests.m in Sources */,
+				A232CCA21AC8FDE800E15D3A /* MSTableOperationErrorTests.m in Sources */,
 				E8F33B3D1616694C002DD7C6 /* MSQueryTests.m in Sources */,
 				E8F33B3E16166956002DD7C6 /* MSJSONSerializerTests.m in Sources */,
 				A258891F18A1A30500962F9A /* MSOfflinePassthroughHelper.m in Sources */,
@@ -904,6 +905,7 @@
 				A22CF3731825914700660C79 /* MSTable+MSTableTestUtilities.m in Sources */,
 				A24701C5196897A700385DA2 /* MSPushHttpTests.m in Sources */,
 				E8E37907161F4D0D00C13F00 /* MSFilterTest.m in Sources */,
+				A232CCA31AC9C86D00E15D3A /* TodoItem.m in Sources */,
 				A295B2B3192AB2040067562E /* MSCoreDataStoreTests.m in Sources */,
 				A29F44A31953CBF30063C0C1 /* MSCoreDataStore+TestHelper.m in Sources */,
 				E84CA4D6162373E2009B2588 /* MSUserAgentBuilderTests.m in Sources */,

--- a/sdk/iOS/src/MSError.h
+++ b/sdk/iOS/src/MSError.h
@@ -87,6 +87,9 @@ extern NSString *const MSErrorPushResultKey;
 /// Indicates that the query key contains invalid characters
 #define MSInvalidQueryId                        -1155
 
+/// Indicates a sync table operation could not be canceled
+#define MSSyncTableCancelError                  -1156
+
 /// Indicates a mobile service sync operation (such as a syncTable insert) failed
 /// because the sync context object was not properly initialized
 #define MSSyncContextInvalid                    -1160

--- a/sdk/iOS/src/MSQueuePushOperation.m
+++ b/sdk/iOS/src/MSQueuePushOperation.m
@@ -193,6 +193,7 @@
             else if (!didCondense) {
                 MSTableOperationError *tableError = [[MSTableOperationError alloc] initWithOperation:operation
                                                                                                 item:operation.item
+                                                                                             context:self.syncContext
                                                                                                error:error];
                 
                 NSError *storeError;
@@ -267,7 +268,7 @@
     if (result.items && result.items.count > 0) {
         NSMutableArray *tableErrors = [NSMutableArray new];
         for (NSDictionary *item in result.items) {
-            [tableErrors addObject:[[MSTableOperationError alloc] initWithSerializedItem:item]];
+            [tableErrors addObject:[[MSTableOperationError alloc] initWithSerializedItem:item context:self.syncContext]];
         }
         
         if (self.error == nil) {

--- a/sdk/iOS/src/MSTableOperationError.h
+++ b/sdk/iOS/src/MSTableOperationError.h
@@ -66,11 +66,15 @@
 /// @name Initializing the MSTableOperationError Object
 /// @{
 
-/// Initializes the table operation error from the provided operation, item, and error objects.
-- (id) initWithOperation:(MSTableOperation *)operation item:(NSDictionary *)item error:(NSError *) error;
+/// Initializes the table operation error from the provided operation, item, error, and context objects.
+- (id) initWithOperation:(MSTableOperation *)operation item:(NSDictionary *)item context:(MSSyncContext *)context error:(NSError *) error;
 
-/// Initializes the table operation error from a serialized representationo of a MSTableOperationError.
-- (id) initWithSerializedItem:(NSDictionary *)item;
+- (id) initWithOperation:(MSTableOperation *)operation item:(NSDictionary *)item error:(NSError *) error __deprecated;
+
+/// Initializes the table operation error from a serialized representation of a MSTableOperationError.
+- (id) initWithSerializedItem:(NSDictionary *)item context:(MSSyncContext *)context;
+
+- (id) initWithSerializedItem:(NSDictionary *)item __deprecated;
 
 ///@}
 

--- a/sdk/iOS/src/MSTableOperationError.m
+++ b/sdk/iOS/src/MSTableOperationError.m
@@ -14,6 +14,7 @@
 
 // Error
 @property (nonatomic) NSInteger code;
+
 @property (nonatomic) NSString *description;
 
 @property (nonatomic, copy) NSString *table;
@@ -27,80 +28,83 @@
 @property (nonatomic) NSString *rawResponse;
 @property (nonatomic) NSDictionary *serverItem;
 
-@property (nonatomic, weak) MSSyncContext *syncContext;
+@property (nonatomic, strong) MSSyncContext *syncContext;
 
 @end
 
+
 @implementation MSTableOperationError
 
-@synthesize handled = handled_;
-
-@synthesize guid = guid_;
-@synthesize code = code_;
-@synthesize description = description_;
-@synthesize table = table_;
-@synthesize operation = operation_;
-@synthesize operationId = operationId_;
-@synthesize itemId = itemId_;
-@synthesize item = item_;
-@synthesize serverItem = serverItem_;
-@synthesize statusCode = statusCode_;
-@synthesize syncContext = syncContext_;
+@synthesize description = _description;
 
 #pragma mark - Initialization
+
 
 - (id) init {
     self = [super init];
     if (self) {
-        guid_ = [MSJSONSerializer generateGUID];
+        _guid = [MSJSONSerializer generateGUID];
     }
     return self;
 }
 
-- (id) initWithOperation:(MSTableOperation *)operation item:(NSDictionary *)item error:(NSError *) error;
+- (id) initWithOperation:(MSTableOperation *)operation item:(NSDictionary *)item context:(MSSyncContext *)context error:(NSError *) error
 {
     self = [self init];
     
-    code_ = error.code;
-    description_ = [error.localizedDescription copy];
-
+    _code = error.code;
+    _description = [error.localizedDescription copy];
+    
     NSHTTPURLResponse *response = [error.userInfo objectForKey:MSErrorResponseKey];
     if (response) {
-        statusCode_ = response.statusCode;
+        _statusCode = response.statusCode;
     }
     
-    serverItem_ = [[[error userInfo] objectForKey:MSErrorServerItemKey] copy];
-
-    table_ = [operation.tableName copy];
-    operation_ = operation.type;
-    itemId_ = [operation.itemId copy];
-    item_ = [item copy];
-    operationId_ = operation.operationId;
+    _serverItem = [[[error userInfo] objectForKey:MSErrorServerItemKey] copy];
+    
+    _table = [operation.tableName copy];
+    _operation = operation.type;
+    _itemId = [operation.itemId copy];
+    _item = [item copy];
+    _operationId = operation.operationId;
+    _syncContext = context;
     
     return self;
 }
 
-- (id) initWithSerializedItem:(NSDictionary *)item
+- (id) initWithOperation:(MSTableOperation *)operation item:(NSDictionary *)item error:(NSError *) error __deprecated;
 {
+    return [[MSTableOperationError alloc] initWithOperation:operation item:item context:nil error:error];
+}
+
+- (id) initWithSerializedItem:(NSDictionary *)item context:(MSSyncContext *)context {
     self = [self init];
     if (self) {
-        guid_ = [item objectForKey:@"id"];
+        _guid = [item objectForKey:@"id"];
         
         // Unserialize the raw data now
         NSData *properties = [item objectForKey:@"properties"];
         MSJSONSerializer *serializer = [MSJSONSerializer new];
         NSDictionary *data = [serializer itemFromData:properties withOriginalItem:nil ensureDictionary:NO orError:nil];
         
-        code_ = [[data objectForKey:@"code"] integerValue];
-        description_ = [data objectForKey:@"description"];
-        table_ = [data objectForKey:@"table"];
-        operation_ = [[data objectForKey:@"operation"] integerValue];
-        itemId_ = [data objectForKey:@"itemId"];
-        item_ = [data objectForKey:@"item"];
-        serverItem_ = [data objectForKey:@"serverItem"];
-        statusCode_ = [[data objectForKey:@"statusCode"] integerValue];
+        _code = [[data objectForKey:@"code"] integerValue];
+        _description = [data objectForKey:@"description"];
+        _table = [data objectForKey:@"table"];
+        _operation = [[data objectForKey:@"operation"] integerValue];
+        _itemId = [data objectForKey:@"itemId"];
+        _item = [data objectForKey:@"item"];
+        _serverItem = [data objectForKey:@"serverItem"];
+        _statusCode = [[data objectForKey:@"statusCode"] integerValue];
+        
+        _syncContext = context;
     }
+    
     return self;
+}
+
+- (id) initWithSerializedItem:(NSDictionary *)item 
+{
+    return [[MSTableOperationError alloc] initWithSerializedItem:item context:nil];
 }
 
 - (NSDictionary *) serialize
@@ -112,7 +116,7 @@
             @"operation": [NSNumber numberWithInteger:self.operation],
             @"itemId": self.itemId,
             @"statusCode": [NSNumber numberWithInteger:self.statusCode]
-    } mutableCopy];
+        } mutableCopy];
     
     if (self.item) {
         [properties setValue:self.item forKey:@"item"];
@@ -123,17 +127,29 @@
     
     MSJSONSerializer *serializer = [MSJSONSerializer new];
     NSError *serializeError;
-    NSData *data = [serializer dataFromItem:properties idAllowed:YES ensureDictionary:NO removeSystemProperties:NO orError:&serializeError];
+    NSData *data = [serializer dataFromItem:properties
+                                  idAllowed:YES
+                           ensureDictionary:NO
+                     removeSystemProperties:NO
+                                    orError:&serializeError];
     
-    // Handle if something is wrong with one of our fields, try again without the possibly breaking fields
+    // Handle if something is wrong with one of our fields, try again without the possibly
+    // breaking fields (item or serverItem could not be serializable)
     if (serializeError.code == MSInvalidItemWithRequest) {
         [properties removeObjectForKey:@"item"];
         [properties removeObjectForKey:@"serverItem"];
         
-        data = [serializer dataFromItem:properties idAllowed:YES ensureDictionary:NO removeSystemProperties:NO orError:&serializeError];
+        data = [serializer dataFromItem:properties
+                              idAllowed:YES
+                       ensureDictionary:NO
+                 removeSystemProperties:NO
+                                orError:&serializeError];
     }
         
-    return @{ @"id": self.guid, @"operationId": [NSNumber numberWithInteger:self.operationId], @"tableKind": @0, @"properties": data };
+    return @{ @"id": self.guid,
+              @"operationId": [NSNumber numberWithInteger:self.operationId],
+              @"tableKind": @0, @"properties": data
+            };
 }
 
 #pragma mark - Error Resolution
@@ -142,13 +158,18 @@
 {
     if (!item) {
         if (completion) {
-            // TODO: Generate error
-            NSError *error = nil;
+            NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: @"Item is required" };
+            NSError *error = [NSError errorWithDomain:MSErrorDomain
+                                                 code:MSSyncTableCancelError
+                                             userInfo:userInfo];
             completion(error);
+            return;
         }
     }
     
-    MSTableOperation *op = [[MSTableOperation alloc] initWithTable:self.table type:self.operation itemId:self.itemId];
+    MSTableOperation *op = [[MSTableOperation alloc] initWithTable:self.table
+                                                              type:self.operation
+                                                            itemId:self.itemId];
     op.operationId = self.operationId;
     op.item = item;
     
@@ -157,12 +178,12 @@
 
 - (void) cancelOperationAndDiscardItemWithCompletion:(MSSyncBlock)completion
 {
-    MSTableOperation *op = [[MSTableOperation alloc] initWithTable:self.table type:self.operation itemId:self.itemId];
+    MSTableOperation *op = [[MSTableOperation alloc] initWithTable:self.table
+                                                              type:self.operation
+                                                            itemId:self.itemId];
     op.operationId = self.operationId;
     
     [self.syncContext cancelOperation:op discardItemWithCompletion:completion];
 }
 
 @end
-
-

--- a/sdk/iOS/src/MSUserAgentBuilder.m
+++ b/sdk/iOS/src/MSUserAgentBuilder.m
@@ -15,7 +15,7 @@ static NSString *const userAgentValueFormat = @"ZUMO/%@ (lang=%@; os=%@; os_vers
 static NSString *const simulatorModel = @"iOSSimulator";
 static NSString *const unknownValue = @"--";
 static NSString *const sdkVersionFormat = @"%d.%d";
-static NSString *const sdkFileVesionFormat = @"%d.%d.%d.beta2";
+static NSString *const sdkFileVesionFormat = @"%d.%d.%d";
 
 
 #pragma mark * MSUserAgentBuilder Implementation

--- a/sdk/iOS/src/WindowsAzureMobileServices.h
+++ b/sdk/iOS/src/WindowsAzureMobileServices.h
@@ -21,7 +21,7 @@
 #import "MSDateOffset.h"
 
 #define WindowsAzureMobileServicesSdkMajorVersion 2
-#define WindowsAzureMobileServicesSdkMinorVersion 0
+#define WindowsAzureMobileServicesSdkMinorVersion 1
 #define WindowsAzureMobileServicesSdkBuildVersion 0
 
 #endif

--- a/sdk/iOS/test/MSTableOperationErrorTests.m
+++ b/sdk/iOS/test/MSTableOperationErrorTests.m
@@ -1,0 +1,215 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+#import "MSClient.h"
+#import "MSCoreDataStore.h"
+#import "MSCoreDataStore+TestHelper.h"
+#import "MSJSONSerializer.h"
+#import "MSOfflinePassthroughHelper.h"
+#import "MSSyncContext.h"
+#import "MSTableOperationInternal.h"
+#import "MSTableOperationError.h"
+#import "TodoItem.h"
+
+@interface MSTableOperationErrorTests : XCTestCase {
+    MSClient *client;
+    BOOL done;
+    MSOfflinePassthroughHelper *offline;
+    NSManagedObjectContext *context;
+}
+@end
+
+
+#pragma mark * Setup and TearDown
+
+@implementation MSTableOperationErrorTests
+
+-(void) setUp
+{
+    NSLog(@"%@ setUp", self.name);
+    
+    client = [MSClient clientWithApplicationURLString:@"https://someUrl/"];
+    context = [MSCoreDataStore inMemoryManagedObjectContext];
+    offline = [[MSOfflinePassthroughHelper alloc] initWithManagedObjectContext:context];
+    
+    // Enable offline mode
+    client.syncContext = [[MSSyncContext alloc] initWithDelegate:offline dataSource:offline callback:nil];
+    
+    done = NO;
+}
+
+-(void) tearDown
+{
+    NSLog(@"%@ tearDown", self.name);
+}
+
+-(void) testBasicInit {
+    MSTableOperation *tableOp = [[MSTableOperation alloc] initWithTable:@"TodoItem" type:MSTableOperationInsert itemId:@"ABC"];
+    NSDictionary *item = @{@"id": @"ABC", @"text": @"item one", @"complete": @NO};
+    
+    NSError *error = [NSError errorWithDomain:MSErrorDomain
+                                         code:MSErrorPreconditionFailed
+                                     userInfo:@{NSLocalizedDescriptionKey: @"Insert error..."}];
+    
+    MSTableOperationError *opError = [[MSTableOperationError alloc] initWithOperation:tableOp
+                                                                                 item:item
+                                                                              context:client.syncContext
+                                                                                error:error];
+    XCTAssertNotNil(opError);
+    
+    XCTAssertEqualObjects(opError.itemId, @"ABC");
+    XCTAssertEqualObjects(opError.table, @"TodoItem");
+    XCTAssertEqual(opError.code, MSErrorPreconditionFailed);
+    XCTAssertEqualObjects(opError.description, @"Insert error...");
+}
+
+-(void) testSerializedInit {
+    MSJSONSerializer *serializer = [MSJSONSerializer new];
+    NSDictionary *details = @{
+        @"id": @"1-2-3",
+        @"code": @MSErrorPreconditionFailed,
+        @"description": @"Insert error...",
+        @"table": @"TodoItem",
+        @"operation": [NSNumber numberWithInteger:MSTableOperationInsert],
+        @"itemId": @"ABC",
+        @"item": @{ @"id":@"ABC", @"text":@"one", @"complete":@NO },
+        @"serverItem": @{ @"id":@"ABC", @"text":@"two", @"complete":@YES },
+        @"statusCode": @312
+    };
+    NSData *data = [serializer dataFromItem:details idAllowed:YES ensureDictionary:NO removeSystemProperties:NO orError:nil];
+    
+    NSDictionary *serializedError = @{
+        @"id": @"1-2-3",
+        @"properties": data
+    };
+    
+    MSTableOperationError *opError = [[MSTableOperationError alloc] initWithSerializedItem:serializedError
+                                                                                   context:client.syncContext];
+    
+    XCTAssertNotNil(opError);
+    XCTAssertEqualObjects(opError.itemId, @"ABC");
+    XCTAssertEqualObjects(opError.table, @"TodoItem");
+    XCTAssertEqual(opError.code, MSErrorPreconditionFailed);
+    XCTAssertEqualObjects(opError.description, @"Insert error...");
+}
+
+-(void) testCancelAndDiscard {
+    NSDictionary *item = @{@"id": @"ABC", @"text": @"initial value" };
+    MSTableOperation *tableOp = [self createPendingOperationForItem:item];
+    MSTableOperationError *opError = [[MSTableOperationError alloc] initWithOperation:tableOp
+                                                                                 item:item
+                                                                              context:client.syncContext
+                                                                                error:nil];
+    // Cancel our operation now
+    XCTestExpectation *cancelExpectation = [self expectationWithDescription:@"CancelAndDiscard"];
+    [opError cancelOperationAndDiscardItemWithCompletion:^(NSError *error) {
+        XCTAssertNil(error);
+        
+        [cancelExpectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+    
+    // Verify item is no longer in the local store layer
+    NSError *error;
+    NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"TodoItem"];
+    NSArray *allTodos = [context executeFetchRequest:fetchRequest error:&error];
+    XCTAssertNil(error);
+    XCTAssertEqual(allTodos.count, 0);
+    
+    // Verify operation is not in the local store layer
+    fetchRequest = [NSFetchRequest fetchRequestWithEntityName:offline.operationTableName];
+    NSArray *allOps = [context executeFetchRequest:fetchRequest error:&error];
+    XCTAssertNil(error);
+    XCTAssertEqual(allOps.count, 0);
+}
+
+-(void) testCancelAndUpdate {
+    NSDictionary *item = @{@"id": @"ABC", @"text": @"initial value" };
+    MSTableOperation *tableOp = [self createPendingOperationForItem:item];
+    MSTableOperationError *opError = [[MSTableOperationError alloc] initWithOperation:tableOp
+                                                                                 item:item
+                                                                              context:client.syncContext
+                                                                                error:nil];
+    
+    // Cancel our pending operation and update the stored value
+    XCTestExpectation *expectation = [self expectationWithDescription:@"CancelAndUpdateOperation"];
+    NSDictionary *newItem = @{ @"id": @"ABC", @"text": @"value two" };
+    [opError cancelOperationAndUpdateItem:newItem completion:^(NSError *error) {
+        XCTAssertNil(error);
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+    
+    // Verify item is updated in the local store layer
+    NSError *error;
+    NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"TodoItem"];
+    NSArray *allTodos = [context executeFetchRequest:fetchRequest error:&error];
+    XCTAssertNil(error);
+    
+    XCTAssertEqual(allTodos.count, 1);
+    TodoItem *updatedItem = allTodos[0];
+    XCTAssertEqualObjects(updatedItem.text, @"value two");
+    
+    // Verify operation is not in the local store layer
+    fetchRequest = [NSFetchRequest fetchRequestWithEntityName:offline.operationTableName];
+    NSArray *allOps = [context executeFetchRequest:fetchRequest error:&error];
+    XCTAssertNil(error);
+    XCTAssertEqual(allOps.count, 0);
+    
+}
+
+-(void) testCancelAndUpdate_NoItem {
+    NSDictionary *item = @{@"id": @"ABC", @"text": @"initial value" };
+    MSTableOperation *tableOp = [self createPendingOperationForItem:item];
+    MSTableOperationError *opError = [[MSTableOperationError alloc] initWithOperation:tableOp
+                                                                                 item:item
+                                                                              context:client.syncContext
+                                                                                error:nil];
+    
+    // Cancel our pending operation and update the stored value
+    XCTestExpectation *expectation = [self expectationWithDescription:@"CancelAndUpdateOperation"];
+    [opError cancelOperationAndUpdateItem:nil completion:^(NSError *error) {
+        XCTAssertNotNil(error);
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+    
+    // Verify operation is still in the local store layer
+    NSError *error = nil;
+    NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:offline.operationTableName];
+    NSArray *allOps = [context executeFetchRequest:fetchRequest error:&error];
+    XCTAssertNil(error);
+    XCTAssertEqual(allOps.count, 1);
+    
+}
+
+- (MSTableOperation *) createPendingOperationForItem:(NSDictionary *)item
+{
+    MSSyncTable *table = [client syncTableWithName:@"TodoItem"];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"UpsertRecord"];
+    [table update:item completion:^(NSError *error) {
+        XCTAssertNil(error);
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+
+    // To be safe, verify operation is in the local store layer
+    NSError *error;
+    NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:offline.operationTableName];
+    NSArray *allOps = [context executeFetchRequest:fetchRequest error:&error];
+    XCTAssertNil(error);
+    XCTAssertEqual(allOps.count, 1);
+    
+    // Create a op that matches what we just did & fake an error
+    MSTableOperation *tableOp = [[MSTableOperation alloc] initWithTable:@"TodoItem" type:MSTableOperationInsert itemId:@"ABC"];
+    tableOp.operationId = [[allOps[0] valueForKey:@"id"] integerValue];
+
+    return tableOp;
+}
+
+@end

--- a/sdk/iOS/test/MSUserAgentBuilderTests.m
+++ b/sdk/iOS/test/MSUserAgentBuilderTests.m
@@ -33,7 +33,7 @@
 {
     NSString *userAgent = [MSUserAgentBuilder userAgent];
     
-    XCTAssertTrue([userAgent isEqualToString:@"ZUMO/2.0 (lang=objective-c; os=--; os_version=--; arch=iOSSimulator; version=2.0.0.beta2)"],
+    XCTAssertTrue([userAgent isEqualToString:@"ZUMO/2.1 (lang=objective-c; os=--; os_version=--; arch=iOSSimulator; version=2.1.0)"],
                  @"user agent was: %@", userAgent);
 }
 


### PR DESCRIPTION
Previously these actions on the MSTableOperationError object would
essentially noop, now they will perform as documented