### PR TITLE
iOS: Update synccontext errors and completions

### DIFF
--- a/sdk/iOS/src/MSQueuePushOperation.h
+++ b/sdk/iOS/src/MSQueuePushOperation.h
@@ -15,6 +15,7 @@
 
 - (id) initWithSyncContext:(MSSyncContext *)syncContext
              dispatchQueue:(dispatch_queue_t)dispatchQueue
+             callbackQueue:(NSOperationQueue *)callbackQueue
                 completion:(MSSyncBlock)completion;
 
 @end

--- a/sdk/iOS/src/MSSyncTable.m
+++ b/sdk/iOS/src/MSSyncTable.m
@@ -10,21 +10,21 @@
 
 @implementation MSSyncTable
 
-@synthesize client = client_;
-@synthesize name = name_;
-
 
 #pragma mark * Public Initializer Methods
 
 
 -(id) initWithName:(NSString *)tableName client:(MSClient *)client;
 {
+    NSAssert(client.syncContext != nil, @"Client must have an initialized MSSyncContext");
+
     self = [super init];
     if (self)
     {
-        client_ = client;
-        name_ = tableName;
+        _client = client;
+        _name = tableName;
     }
+    
     return self;
 }
 

--- a/sdk/iOS/test/MSCoreDataStoreTests.m
+++ b/sdk/iOS/test/MSCoreDataStoreTests.m
@@ -14,6 +14,7 @@
 }
 @property (nonatomic, strong) MSCoreDataStore *store;
 @property (nonatomic, strong) NSManagedObjectContext *context;
+@property (nonatomic, strong) MSClient *client;
 
 @end
 
@@ -25,6 +26,9 @@
     
     self.context = [MSCoreDataStore inMemoryManagedObjectContext];
     self.store = [[MSCoreDataStore alloc] initWithManagedObjectContext:self.context];
+    self.client = [MSClient clientWithApplicationURLString:@""];
+    self.client.syncContext = [[MSSyncContext alloc] initWithDelegate:nil dataSource:self.store callback:nil];
+    
     XCTAssertNotNil(self.store, @"In memory store could not be created");
     
     done = NO;
@@ -58,7 +62,7 @@
     XCTAssertNotNil(item[MSSystemColumnVersion], @"__version was missing");
     XCTAssertNil(item[@"ms_version"], @"__version was missing");
     
-    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"TodoItem" client:nil];
+    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"TodoItem" client:self.client];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoItem predicate:nil];
     
     MSSyncContextReadResult *result = [self.store readWithQuery:query orError:&error];
@@ -88,7 +92,7 @@
     XCTAssertEqualObjects(item[@"id"], @"B");
     XCTAssertEqualObjects(item[@"text"], @"test2");
     
-    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"TodoItem" client:nil];
+    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"TodoItem" client:self.client];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoItem predicate:nil];
     
     MSSyncContextReadResult *result = [self.store readWithQuery:query orError:&error];
@@ -111,7 +115,7 @@
     XCTAssertNil(item[MSSystemColumnVersion]);
     XCTAssertNil(item[@"ms_version"]);
     
-    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"TodoNoVersion" client:nil];
+    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"TodoNoVersion" client:self.client];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoItem predicate:nil];
     
     MSSyncContextReadResult *result = [self.store readWithQuery:query orError:&error];
@@ -169,7 +173,8 @@
     
     // Repeat for query
     
-    MSSyncTable *manySystemColumns = [[MSSyncTable alloc] initWithName:@"ManySystemColumns" client:nil];
+    MSSyncTable *manySystemColumns = [[MSSyncTable alloc] initWithName:@"ManySystemColumns"
+                                                                client:self.client];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:manySystemColumns predicate:nil];
     
     MSSyncContextReadResult *result = [self.store readWithQuery:query orError:&error];
@@ -209,7 +214,7 @@
     
     [self populateTestData];
     
-    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"TodoItem" client:nil];
+    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"TodoItem" client:self.client];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoItem predicate:nil];
     query.predicate = [NSPredicate predicateWithFormat:@"text == 'test3'"];
     
@@ -226,7 +231,7 @@
     
     [self populateTestData];
     
-    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"TodoItem" client:nil];
+    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"TodoItem" client:self.client];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoItem predicate:nil];
     query.fetchLimit = 1;
     query.includeTotalCount = YES;
@@ -244,7 +249,7 @@
     
     [self populateTestData];
     
-    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"TodoItem" client:nil];
+    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"TodoItem" client:self.client];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoItem predicate:nil];
     [query orderByAscending:@"sort"];
     
@@ -263,7 +268,7 @@
     
     [self populateTestData];
     
-    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"TodoItem" client:nil];
+    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"TodoItem" client:self.client];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoItem predicate:nil];
     [query orderByDescending:@"sort"];
     
@@ -282,7 +287,7 @@
     
     [self populateTestData];
     
-    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"TodoItem" client:nil];
+    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"TodoItem" client:self.client];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoItem predicate:nil];
     query.selectFields = @[@"sort", @"text"];
     
@@ -314,7 +319,8 @@
     XCTAssertNil(error, @"Upsert failed: %@", error.description);
     
     // Now check selecting subset of columns
-    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"ManySystemColumns" client:nil];
+    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"ManySystemColumns"
+                                                       client:self.client];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoItem predicate:nil];
     query.selectFields = @[@"text", @"__version", @"__meaningOfLife"];
     
@@ -334,7 +340,7 @@
 {
     NSError *error;
 
-    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"NoSuchTable" client:nil];
+    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"NoSuchTable" client:self.client];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoItem predicate:nil];
     
     MSSyncContextReadResult *result = [self.store readWithQuery:query orError:&error];
@@ -400,7 +406,7 @@
     
     [self populateTestData];
 
-    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"TodoItem" client:nil];
+    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"TodoItem" client:self.client];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoItem predicate:nil];
     
     [self.store deleteUsingQuery:query orError:&error];
@@ -418,7 +424,7 @@
     
     [self populateTestData];
     
-    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"TodoItem" client:nil];
+    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"TodoItem" client:self.client];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoItem predicate:nil];
     query.predicate = [NSPredicate predicateWithFormat:@"text == 'test3'"];
     
@@ -438,7 +444,7 @@
 {
     NSError *error;
     
-    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"NoSuchTable" client:nil];
+    MSSyncTable *todoItem = [[MSSyncTable alloc] initWithName:@"NoSuchTable" client:self.client];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoItem predicate:nil];
     query.predicate = [NSPredicate predicateWithFormat:@"text == 'test3'"];
     

--- a/sdk/iOS/test/MSOfflinePassthroughHelper.h
+++ b/sdk/iOS/test/MSOfflinePassthroughHelper.h
@@ -25,6 +25,8 @@
 @property (nonatomic) BOOL errorOnReadWithQueryOrError;
 @property (nonatomic) BOOL errorOnReadTableWithItemIdOrError;
 
+@property (nonatomic) BOOL errorOnUpsertItemsForOperations;
+
 @property (nonatomic, strong) NSMutableDictionary *data;
 
 -(void) resetCounts;

--- a/sdk/iOS/test/MSOfflinePassthroughHelper.m
+++ b/sdk/iOS/test/MSOfflinePassthroughHelper.m
@@ -22,6 +22,11 @@
 {
     self.upsertCalls++;
     
+    if (self.errorOnUpsertItemsForOperations && table == self.operationTableName) {
+        *error = [NSError errorWithDomain:@"TestError" code:1 userInfo:nil];
+        return NO;
+    }
+    
     if ([super upsertItems:items table:table orError:error]) {
         self.upsertedItems += items.count;
         return YES;

--- a/sdk/iOS/test/MSSyncTableTests.m
+++ b/sdk/iOS/test/MSSyncTableTests.m
@@ -21,6 +21,7 @@
 
 static NSString *const TodoTableNoVersion = @"TodoNoVersion";
 static NSString *const AllColumnTypesTable = @"ColumnTypes";
+static NSString *const SyncContextQueueName = @"Sync Context: Operation Callbacks";
 
 @interface MSSyncTableTests : XCTestCase {
     MSClient *client;
@@ -76,6 +77,7 @@ static NSString *const AllColumnTypesTable = @"ColumnTypes";
     // Insert the item
     [todoTable insert:item completion:^(NSDictionary *item, NSError *error) {
         XCTAssertNotNil(item[@"id"], @"The item should have an id");
+        XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
         done = YES;
     }];
     
@@ -95,6 +97,7 @@ static NSString *const AllColumnTypesTable = @"ColumnTypes";
     [todoTable insert:item completion:^(NSDictionary *item, NSError *error) {
         XCTAssertNotNil(error, @"error should have been set.");
         XCTAssertTrue(error.localizedDescription, @"The item provided must not have an id.");
+        XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
         done = YES;
     }];
     
@@ -112,6 +115,7 @@ static NSString *const AllColumnTypesTable = @"ColumnTypes";
     [todoTable insert:item completion:^(NSDictionary *item, NSError *error) {
         XCTAssertNotNil(error, @"error should have been set.");
         XCTAssertTrue(error.localizedDescription, @"The item provided was not valid.");
+        XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
         done = YES;
     }];
     
@@ -129,7 +133,8 @@ static NSString *const AllColumnTypesTable = @"ColumnTypes";
     // Insert the item
     [todoTable insert:item completion:^(NSDictionary *item, NSError *error) {
         XCTAssertNotNil(error, @"error should have been set.");
-        //STAssertTrue(error.localizedDescription, @"The item provided was not valid.");
+        XCTAssertEqualObjects(error.localizedDescription, @"Missing required datasource for MSSyncContext");
+        XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
         done = YES;
     }];
     
@@ -177,6 +182,7 @@ static NSString *const AllColumnTypesTable = @"ColumnTypes";
     [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(insertRanToServer, @"the insert call didn't go to the server");
+        XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
         done = YES;
     }];
     XCTAssertTrue([self waitForTest:2000.1], @"Test timed out.");
@@ -222,6 +228,7 @@ static NSString *const AllColumnTypesTable = @"ColumnTypes";
     [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(insertRanToServer, @"the insert call didn't go to the server");
+        XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
         done = YES;
     }];
     XCTAssertTrue([self waitForTest:2000.1], @"Test timed out.");
@@ -267,6 +274,8 @@ static NSString *const AllColumnTypesTable = @"ColumnTypes";
         
         MSTableOperationError *tableError = [pushErrors objectAtIndex:0];
         XCTAssertEqual(tableError.code, MSInvalidItemWithRequest);
+
+        XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
         
         done = YES;
     }];
@@ -334,6 +343,8 @@ static NSString *const AllColumnTypesTable = @"ColumnTypes";
     [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(insertRanToServer, @"the insert call didn't go to the server");
+        XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
+        
         done = YES;
     }];
     XCTAssertTrue([self waitForTest:2000.1], @"Test timed out.");
@@ -395,6 +406,8 @@ static NSString *const AllColumnTypesTable = @"ColumnTypes";
         
         NSDictionary *actualItem = errorInfo.serverItem;
         XCTAssertNotNil(actualItem, @"Expected server version to be present");
+
+        XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
         
         done = YES;
     }];
@@ -456,6 +469,8 @@ static NSString *const AllColumnTypesTable = @"ColumnTypes";
     [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(callsToServer == 1, @"only one call to server should have been made");
+        XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
+        
         done = YES;
     }];
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
@@ -509,6 +524,8 @@ static NSString *const AllColumnTypesTable = @"ColumnTypes";
     [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(callsToServer == 0, @"no calls to server should have been made");
+        XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
+        
         done = YES;
     }];
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
@@ -523,6 +540,7 @@ static NSString *const AllColumnTypesTable = @"ColumnTypes";
         [todoTable insert:itemOne completion:^(NSDictionary *itemTwo, NSError *error) {
             XCTAssertNotNil(error, @"expected an error");
             XCTAssertTrue(error.code == MSSyncTableInvalidAction, @"unexpected error code");
+            XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
             done = YES;
         }];
     }];
@@ -552,6 +570,8 @@ static NSString *const AllColumnTypesTable = @"ColumnTypes";
     [todoTable insert:item completion:^(NSDictionary *i, NSError *error) {
         XCTAssertNotNil(error);
         XCTAssertEqual(error.code, MSSyncTableInvalidAction);
+        XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
+        
         done = YES;
     }];
     
@@ -575,6 +595,8 @@ static NSString *const AllColumnTypesTable = @"ColumnTypes";
         XCTAssertEqual(error.code, 1);
         XCTAssertEqual(offline.upsertCalls, 0);
         XCTAssertEqual(offline.readTableCalls, 1);
+        XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
+        
         done = YES;
     }];
     
@@ -589,6 +611,7 @@ static NSString *const AllColumnTypesTable = @"ColumnTypes";
         XCTAssertNil(error);
         XCTAssertEqual(offline.upsertCalls, 2); // one for the item, one for the operation
         XCTAssertEqual(offline.readTableCalls, 1);
+        
         // push it to clear out pending operations
         [todoTable.client.syncContext pushWithCompletion:^(NSError *error) {
             done = YES;
@@ -607,10 +630,28 @@ static NSString *const AllColumnTypesTable = @"ColumnTypes";
         XCTAssertEqual(error.code, 1);
         XCTAssertEqual(offline.upsertCalls, 0);
         XCTAssertEqual(offline.readTableCalls, 1);
+        XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
+        
         done = YES;
     }];
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
+}
+
+-(void) testInsertWithOperationError {
+    XCTestExpectation *expectation = [self expectationWithDescription:self.name];
+    MSSyncTable *todoTable = [client syncTableWithName:TodoTableNoVersion];
+    
+    // Insert an item
+    offline.errorOnUpsertItemsForOperations = YES;
+    [todoTable insert:@{ @"name":@"test name" } completion:^(NSDictionary *item, NSError *error) {
+        XCTAssertNotNil(error);
+        XCTAssertNil(item);
+        XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
 
@@ -641,6 +682,7 @@ static NSString *const AllColumnTypesTable = @"ColumnTypes";
     done = NO;
     [todoTable update:item completion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
+        XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
         done = YES;
     }];
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
@@ -649,6 +691,7 @@ static NSString *const AllColumnTypesTable = @"ColumnTypes";
     [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(updateSentToServer, @"the update call didn't go to the server");
+        XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
         done = YES;
     }];
     XCTAssertTrue([self waitForTest:2000.1], @"Test timed out.");


### PR DESCRIPTION
Fix completion blocks not occurring on the specified callback queue.

Surface operation write errors to callers when they occur post item update.