### PR TITLE
iOS: Update sync table insert tests

### DIFF
--- a/sdk/iOS/test/MSJSONSerializerTests.m
+++ b/sdk/iOS/test/MSJSONSerializerTests.m
@@ -232,7 +232,7 @@
     dateParts.hour = 15;
     dateParts.minute = 44;
     dateParts.calendar = [[NSCalendar alloc]
-                          initWithCalendarIdentifier:NSGregorianCalendar];
+                          initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
     dateParts.calendar.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
     
     NSDate *date1 = dateParts.date;
@@ -509,12 +509,12 @@
     XCTAssertNotNil(date, @"date was nil after deserializing item.");
     
     NSCalendar *gregorian = [[NSCalendar alloc]
-                             initWithCalendarIdentifier:NSGregorianCalendar];
+                             initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
     [gregorian setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
     NSDateComponents *dateParts =
-        [gregorian components:(NSYearCalendarUnit |
-                               NSHourCalendarUnit |
-                               NSSecondCalendarUnit)
+        [gregorian components:(NSCalendarUnitYear |
+                               NSCalendarUnitHour |
+                               NSCalendarUnitSecond)
                      fromDate:date];
 
     XCTAssertEqual(dateParts.year, 1999);
@@ -540,12 +540,12 @@
     XCTAssertNotNil(date, @"date was nil after deserializing item.");
     
     NSCalendar *gregorian = [[NSCalendar alloc]
-                             initWithCalendarIdentifier:NSGregorianCalendar];
+                             initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
     [gregorian setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
     NSDateComponents *dateParts =
-    [gregorian components:(NSYearCalendarUnit |
-                           NSHourCalendarUnit |
-                           NSSecondCalendarUnit)
+    [gregorian components:(NSCalendarUnitYear |
+                           NSCalendarUnitHour |
+                           NSCalendarUnitSecond)
                  fromDate:date];
     
     XCTAssertEqual(dateParts.year, 1999);
@@ -664,12 +664,12 @@
     XCTAssertNotNil(date, @"date was nil after deserializing item.");
     
     NSCalendar *gregorian = [[NSCalendar alloc]
-                             initWithCalendarIdentifier:NSGregorianCalendar];
+                             initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
     [gregorian setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
     NSDateComponents *dateParts =
-    [gregorian components:(NSYearCalendarUnit |
-                           NSHourCalendarUnit |
-                           NSSecondCalendarUnit)
+    [gregorian components:(NSCalendarUnitYear |
+                           NSCalendarUnitHour |
+                           NSCalendarUnitSecond)
                  fromDate:date];
     
     
@@ -681,9 +681,9 @@
     XCTAssertNotNil(date2, @"date was nil after deserializing item.");
 
     NSDateComponents *dateParts2 =
-    [gregorian components:(NSYearCalendarUnit |
-                           NSHourCalendarUnit |
-                           NSSecondCalendarUnit)
+    [gregorian components:(NSCalendarUnitYear |
+                           NSCalendarUnitHour |
+                           NSCalendarUnitSecond)
                  fromDate:date2];
 
     XCTAssertEqual(dateParts2.year, 2012);

--- a/sdk/iOS/test/MSPredicateTranslatorTests.m
+++ b/sdk/iOS/test/MSPredicateTranslatorTests.m
@@ -19,7 +19,7 @@
     dateParts.month = 5;
     dateParts.day = 21;
     dateParts.calendar = [[NSCalendar alloc]
-                           initWithCalendarIdentifier:NSGregorianCalendar];
+                           initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
     dateParts.calendar.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
     
     NSDate *date1 = dateParts.date;
@@ -186,7 +186,7 @@
     dateParts.month = 5;
     dateParts.day = 21;
     dateParts.calendar = [[NSCalendar alloc]
-                          initWithCalendarIdentifier:NSGregorianCalendar];
+                          initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
     dateParts.calendar.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
     
     NSDate *date1 = dateParts.date;

--- a/sdk/iOS/test/WindowsAzureMobileServicesFunctionalTests.m
+++ b/sdk/iOS/test/WindowsAzureMobileServicesFunctionalTests.m
@@ -486,7 +486,7 @@
         XCTAssertNotNil(error, @"error should not have been nil.");
         XCTAssertTrue(error.domain == MSErrorDomain,
                      @"error domain should have been MSErrorDomain.");
-        NSLog([NSString stringWithFormat:@"%ld",error.code]);
+        NSLog(@"%ld", (long)error.code);
         XCTAssertTrue(error.code == MSErrorMessageErrorCode,
                      @"error code should have been MSErrorMessageErrorCode.");
         


### PR DESCRIPTION
Modify some insert tests and fix up some unit test checks

Clean up some warnings from deprecations in iOS 8