### PR TITLE
iOS: Observe context directly

### DIFF
--- a/sdk/iOS/WindowsAzureMobileServices.xcodeproj/project.pbxproj
+++ b/sdk/iOS/WindowsAzureMobileServices.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		A28224B0192ACEAE00EF8743 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A28224AF192ACEAE00EF8743 /* CoreData.framework */; };
 		A28224B3192ACFB700EF8743 /* CoreDataTestModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = A28224B1192ACFB700EF8743 /* CoreDataTestModel.xcdatamodeld */; };
 		A28224B4192AD00E00EF8743 /* CoreDataTestModel.xcdatamodeld in Resources */ = {isa = PBXBuildFile; fileRef = A28224B1192ACFB700EF8743 /* CoreDataTestModel.xcdatamodeld */; };
-		A28DD6361A83FDEA00F1A1C5 /* MSManagedObjectObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = A28DD6341A83FDEA00F1A1C5 /* MSManagedObjectObserver.h */; };
+		A28DD6361A83FDEA00F1A1C5 /* MSManagedObjectObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = A28DD6341A83FDEA00F1A1C5 /* MSManagedObjectObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A28DD6371A83FDEA00F1A1C5 /* MSManagedObjectObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = A28DD6351A83FDEA00F1A1C5 /* MSManagedObjectObserver.m */; };
 		A295B2B3192AB2040067562E /* MSCoreDataStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A295B2B2192AB2040067562E /* MSCoreDataStoreTests.m */; };
 		A29F44A31953CBF30063C0C1 /* MSCoreDataStore+TestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = A29F44A21953CBF30063C0C1 /* MSCoreDataStore+TestHelper.m */; };
@@ -665,7 +665,6 @@
 				E8E3790E161F769D00C13F00 /* MSClient.h in Headers */,
 				E8E37911161F769D00C13F00 /* MSTable.h in Headers */,
 				A24701B7196896F500385DA2 /* MSLocalStorage.h in Headers */,
-				A28DD6361A83FDEA00F1A1C5 /* MSManagedObjectObserver.h in Headers */,
 				A24701BD196896F500385DA2 /* MSPushRequest.h in Headers */,
 				E8E37910161F769D00C13F00 /* MSQuery.h in Headers */,
 				A258890F18A19D0B00962F9A /* MSTableOperation.h in Headers */,
@@ -676,6 +675,7 @@
 				E8E37913161F769D00C13F00 /* MSFilter.h in Headers */,
 				A2ACD540192322C50012B1ED /* MSCoreDataStore.h in Headers */,
 				CF762EC61A1D366E0018C292 /* MSDateOffset.h in Headers */,
+				A28DD6361A83FDEA00F1A1C5 /* MSManagedObjectObserver.h in Headers */,
 				A24701B9196896F500385DA2 /* MSPush.h in Headers */,
 				870C0C9C199C246700A134DD /* MSSDKFeatures.h in Headers */,
 				E8E3790F161F769D00C13F00 /* MSError.h in Headers */,

--- a/sdk/iOS/src/MSClient.m
+++ b/sdk/iOS/src/MSClient.m
@@ -138,7 +138,7 @@
     
     // Filter clients should inherit the same sync context
     newClient.syncContext = self.syncContext;
-    
+
     // Either copy or create a new filters array
     NSMutableArray *filters = [self.filters mutableCopy];
     if (!filters) {
@@ -276,8 +276,6 @@
     client.currentUser = [self.currentUser copyWithZone:zone];
     client.filters = [self.filters copyWithZone:zone];
 	
-	client.syncContext = [[MSSyncContext alloc] initWithDelegate:self.syncContext.delegate dataSource:self.syncContext.dataSource callback:self.syncContext.callbackQueue];
-
     return client;
 }
 

--- a/sdk/iOS/src/MSCoreDataStore.m
+++ b/sdk/iOS/src/MSCoreDataStore.m
@@ -256,7 +256,7 @@ NSString *const StoreDeleted = @"ms_deleted";
                 return [columnName hasPrefix:SystemColumnPrefix];
             }];
             
-            __block bool hasVersion;
+            __block bool hasVersion = false;
             [systemColumnIndexes enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL *stop) {
                 NSString *columnName = [properties objectAtIndex:idx];
                 if (!hasVersion && versionProperty) {

--- a/sdk/iOS/src/MSManagedObjectObserver.h
+++ b/sdk/iOS/src/MSManagedObjectObserver.h
@@ -1,21 +1,25 @@
-//
-//  MSManagedObjectObserver.h
-//  WindowsAzureMobileServices
-//
-//  Created by Phillip Van Nortwick on 2/5/15.
-//  Copyright (c) 2015 Windows Azure. All rights reserved.
-//
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
 #import "MSTableOperation.h"
 
-typedef void (^MSManagedObjectObserverCompletionBlock)(MSTableOperationTypes operationType, NSDictionary *item, NSError *error);
+typedef void (^MSManagedObjectObserverCompletionBlock)(MSTableOperationTypes operationType,
+                                                       NSDictionary *item,
+                                                       NSError *error);
 
 @class MSClient;
 
 @interface MSManagedObjectObserver : NSObject
 
-- (instancetype) initWithClient:(MSClient *)client;
+/// The MSCoreDataStore class is for use when using the offline capabilities
+/// of mobile services. This class is a local store which manages records and sync
+/// logic using CoreData.
+
+- (instancetype) initWithClient:(MSClient *)client context:(NSManagedObjectContext *)context;
 
 /// Block to be called on each operation that will is inserted into MS_TableOperations
 ///

--- a/sdk/iOS/test/MSManagedObjectObserverTests.m
+++ b/sdk/iOS/test/MSManagedObjectObserverTests.m
@@ -18,6 +18,7 @@
 @property (nonatomic, strong) MSClient *client;
 @property (nonatomic, strong) MSCoreDataStore *store;
 @property (nonatomic, strong) NSManagedObjectContext *context;
+@property (nonatomic, strong) NSManagedObjectContext *storeContext;
 @property (nonatomic, strong) MSManagedObjectObserver *observer;
 
 @property (nonatomic, strong) TodoItem *item;
@@ -28,7 +29,7 @@
 /// Helper method so we can start observing at the point we want to rather than initialized during setup
 - (void)startObservingContextWithObservationCompletion:(MSManagedObjectObserverCompletionBlock)completionBlock
 {
-	self.observer = [[MSManagedObjectObserver alloc] initWithClient:self.client];
+    self.observer = [[MSManagedObjectObserver alloc] initWithClient:self.client context: self.context];
 	self.observer.observerActionCompleted = completionBlock;
 }
 
@@ -47,7 +48,9 @@
     [super setUp];
 	
 	self.context = [MSCoreDataStore inMemoryManagedObjectContext];
-	self.store = [[MSCoreDataStore alloc] initWithManagedObjectContext:self.context];
+    self.storeContext = [MSCoreDataStore inMemoryManagedObjectContext];
+    
+    self.store = [[MSCoreDataStore alloc] initWithManagedObjectContext:self.storeContext];
 	
 	self.client = [[MSClient alloc] initWithApplicationURL:nil applicationKey:nil];
 	self.client.syncContext = [[MSSyncContext alloc] initWithDelegate:nil dataSource:self.store callback:nil];
@@ -66,7 +69,7 @@
 	
 	[self startObservingContextWithObservationCompletion:^(MSTableOperationTypes operationType, NSDictionary *item, NSError *error) {
 		NSFetchRequest *tableOperationsRequest = [NSFetchRequest fetchRequestWithEntityName:@"MS_TableOperations"];
-		NSArray *tableOperations = [self.context executeFetchRequest:tableOperationsRequest error:nil];
+		NSArray *tableOperations = [self.storeContext executeFetchRequest:tableOperationsRequest error:nil];
 		
 		XCTAssertEqual(tableOperations.count, 1, @"Should have one insert operation after the save of TodoItem %@", self.item);
 		
@@ -103,7 +106,7 @@
 	// Start observing after insert as we are only concerned about subsequent updates
 	[self startObservingContextWithObservationCompletion:^(MSTableOperationTypes operationType, NSDictionary *item, NSError *error) {
 		NSFetchRequest *tableOperationsRequest = [NSFetchRequest fetchRequestWithEntityName:@"MS_TableOperations"];
-		NSArray *tableOperations = [self.context executeFetchRequest:tableOperationsRequest error:nil];
+		NSArray *tableOperations = [self.storeContext executeFetchRequest:tableOperationsRequest error:nil];
 		
 		XCTAssertEqual(tableOperations.count, 1, @"Should have one insert operation after the save of TodoItem %@", self.item);
 		
@@ -142,7 +145,7 @@
 	
 	[self startObservingContextWithObservationCompletion:^(MSTableOperationTypes operationType, NSDictionary *item, NSError *error) {
 		NSFetchRequest *tableOperationsRequest = [NSFetchRequest fetchRequestWithEntityName:@"MS_TableOperations"];
-		NSArray *tableOperations = [self.context executeFetchRequest:tableOperationsRequest error:nil];
+		NSArray *tableOperations = [self.storeContext executeFetchRequest:tableOperationsRequest error:nil];
 		
 		XCTAssertEqual(tableOperations.count, 1, @"Should have one insert operation after the save of TodoItem %@", self.item);
 		

--- a/sdk/iOS/test/MSSyncTableTests.m
+++ b/sdk/iOS/test/MSSyncTableTests.m
@@ -164,11 +164,6 @@ static NSString *const AllColumnTypesTable = @"ColumnTypes";
 
 -(void) testInsertWithIgnoreSuccess
 {
-    [self helpInsertWithIgnore:YES];
-}
-
--(void) helpInsertWithIgnore:(BOOL) ignore
-{
     MSTestFilter *testFilter = [MSTestFilter testFilterWithStatusCode:500];
     MSClient *filteredClient = [client clientWithFilter:testFilter];
     offline.handlesSyncTableOperations = NO;
@@ -183,12 +178,14 @@ static NSString *const AllColumnTypesTable = @"ColumnTypes";
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
-    // Expect 1 upsert for item, 1 for operation
-    XCTAssertEqual(offline.upsertCalls, 2);
+    // Expect 1 for operation, 0 for item operation saves
+    XCTAssertEqual(offline.upsertCalls, 1);
     
     NSError *error = nil;
+
+    // Now verify item was not inserted as well
     NSDictionary *savedItem = [offline readTable:TodoTableNoVersion withItemId:@"test1" orError:&error];
-    XCTAssertNotNil(savedItem, @"Unable to find expected item in store");
+    XCTAssertNil(savedItem, @"Find unexpected item in store");
 }
 
 -(void) testInsertItemWithValidId


### PR DESCRIPTION
Changing the observer usage pattern to take a context to observe directly.  Long term it should probably take an optional array to observe.

Updates test cases to reflect the change, and some minor other updates.