### PR TITLE
Update header import statements

### DIFF
--- a/sdk/iOS/WindowsAzureMobileServices.xcodeproj/project.pbxproj
+++ b/sdk/iOS/WindowsAzureMobileServices.xcodeproj/project.pbxproj
@@ -300,6 +300,7 @@
 		E8F33B36161668DA002DD7C6 /* MSJSONSerializerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSJSONSerializerTests.m; sourceTree = "<group>"; };
 		E8F33B38161668E4002DD7C6 /* MSPredicateTranslatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSPredicateTranslatorTests.m; sourceTree = "<group>"; };
 		E8F33B3A161668ED002DD7C6 /* MSQueryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSQueryTests.m; sourceTree = "<group>"; };
+		F3EE33E21AF2C0C9009874A0 /* BlockDefinitions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BlockDefinitions.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -529,6 +530,7 @@
 				E8F33B1B161667EC002DD7C6 /* Serialization */,
 				E8F33B1C161667F6002DD7C6 /* Query */,
 				E8F33AE11616659C002DD7C6 /* Supporting Files */,
+				F3EE33E21AF2C0C9009874A0 /* BlockDefinitions.h */,
 			);
 			name = Source;
 			path = src;

--- a/sdk/iOS/src/BlockDefinitions.h
+++ b/sdk/iOS/src/BlockDefinitions.h
@@ -1,0 +1,78 @@
+//
+//  BlockDefinitions.h
+//  WindowsAzureMobileServices
+//
+//  Created by Damien Pontifex on 30/04/2015.
+//  Copyright (c) 2015 Windows Azure. All rights reserved.
+//
+
+#ifndef WindowsAzureMobileServices_BlockDefinitions_h
+#define WindowsAzureMobileServices_BlockDefinitions_h
+
+@class MSUser;
+@class MSQueryResult;
+
+#pragma	mark * MSSyncContext
+
+/// Callback for updates and deletes. If there was an error, the *error* will be non-nil.
+typedef void (^MSSyncBlock)(NSError *error);
+
+/// Callback for inserts. If there was an error, the *error* will be non-nil.
+typedef void (^MSSyncItemBlock)(NSDictionary *item, NSError *error);
+
+/// Callback for push operations
+typedef void (^MSSyncPushCompletionBlock)(void);
+
+#pragma	mark * MSLoginController
+/// Callback logging in an end user. If there was an error or the login was
+/// cancelled, *error* will be non-nil.
+typedef void (^MSClientLoginBlock)(MSUser *user, NSError *error);
+
+#pragma mark * MSClient
+/// Callback for method with no return other than error.
+typedef void (^MSCompletionBlock)(NSError *error);
+
+/// Callback for invokeAPI method that expects a JSON result.
+typedef void (^MSAPIBlock)(id result, NSHTTPURLResponse *response, NSError *error);
+
+/// Callback for the invokeAPI method that can return any media type.
+typedef void (^MSAPIDataBlock)(NSData *result,
+							   NSHTTPURLResponse *response,
+							   NSError *error);
+
+#pragma mark * MSTable
+
+/// Callback for updates, inserts or readWithId requests. If there was an
+/// error, the *error* will be non-nil.
+typedef void (^MSItemBlock)(NSDictionary *item, NSError *error);
+
+/// Callback for deletes. If there was an error, the *error* will be non-nil.
+typedef void (^MSDeleteBlock)(id itemId, NSError *error);
+
+/// Callback for reads. If there was an error, the *error* will be non-nil. If
+/// there was not an error, then the result will always be non-nil
+/// but but items may be empty if the query returned no results. If the query included a
+/// request for the total count of items on the server (not just those returned
+/// in *items* array), the *totalCount* in the result will have this value; otherwise
+/// *totalCount* will be -1.
+/// if the server returned a link to next page of results then
+/// nextLink will be non-nil.
+typedef void (^MSReadQueryBlock)(MSQueryResult *result,
+								 NSError *error);
+
+#pragma mark * MSClientConnection
+
+
+// Callback for connections. If there was an error, the |error| will be non-nil.
+// If there was not an error, the |response| will be non-nil, but
+// the |data| may or may not be nil depending on if the response had content.
+typedef void (^MSResponseBlock)(NSHTTPURLResponse *response,
+								NSData *data,
+								NSError *error);
+
+#pragma mark * MSPushHttp
+
+typedef void (^MSCreateRegistrationIdBlock)(NSString *registrationId, NSError *error);
+typedef void (^MSListRegistrationsBlock)(NSArray *registrations, NSError *error);
+
+#endif

--- a/sdk/iOS/src/MSAPIConnection.h
+++ b/sdk/iOS/src/MSAPIConnection.h
@@ -2,8 +2,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // ----------------------------------------------------------------------------
 
+@class MSAPIRequest;
+@class MSClient;
+
 #import "MSClientConnection.h"
-#import "MSAPIRequest.h"
 
 
 #pragma  mark * MSAPIConnection Public Interface

--- a/sdk/iOS/src/MSAPIConnection.m
+++ b/sdk/iOS/src/MSAPIConnection.m
@@ -3,7 +3,7 @@
 // ----------------------------------------------------------------------------
 
 #import "MSAPIConnection.h"
-
+#import "MSAPiRequest.h"
 
 #pragma mark * MSAPIConnection Private Interface
 

--- a/sdk/iOS/src/MSAPIRequest.h
+++ b/sdk/iOS/src/MSAPIRequest.h
@@ -3,7 +3,8 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSClient.h"
+#import "BlockDefinitions.h"
+@class MSClient;
 #import "MSSerializer.h"
 
 

--- a/sdk/iOS/src/MSClient.h
+++ b/sdk/iOS/src/MSClient.h
@@ -4,28 +4,17 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import "BlockDefinitions.h"
 #import "MSError.h"
-#import "MSFilter.h"
-#import "MSLoginController.h"
-#import "MSSyncContext.h"
 
 @class MSTable;
 @class MSUser;
 @class MSSyncTable;
 @class MSPush;
+@class MSSyncContext;
+@class MSLoginController;
 
-
-#pragma mark * Block Type Definitions
-/// Callback for method with no return other than error.
-typedef void (^MSCompletionBlock)(NSError *error);
-
-/// Callback for invokeAPI method that expects a JSON result.
-typedef void (^MSAPIBlock)(id result, NSHTTPURLResponse *response, NSError *error);
-
-/// Callback for the invokeAPI method that can return any media type.
-typedef void (^MSAPIDataBlock)(NSData *result,
-                               NSHTTPURLResponse *response,
-                               NSError *error);
+@protocol MSFilter;
 
 #pragma  mark * MSClient Public Interface
 

--- a/sdk/iOS/src/MSClient.m
+++ b/sdk/iOS/src/MSClient.m
@@ -6,6 +6,7 @@
 #import "MSTable.h"
 #import "MSClientConnection.h"
 #import "MSLogin.h"
+#import "MSLoginController.h"
 #import "MSUser.h"
 #import "MSAPIRequest.h"
 #import "MSAPIConnection.h"

--- a/sdk/iOS/src/MSClientConnection.h
+++ b/sdk/iOS/src/MSClientConnection.h
@@ -3,19 +3,10 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSClient.h"
+#import "BlockDefinitions.h"
+
+@class MSClient;
 #import "MSSerializer.h"
-
-
-#pragma mark * Block Type Definitions
-
-
-// Callback for connections. If there was an error, the |error| will be non-nil.
-// If there was not an error, the |response| will be non-nil, but
-// the |data| may or may not be nil depending on if the response had content.
-typedef void (^MSResponseBlock)(NSHTTPURLResponse *response,
-                                NSData *data,
-                                NSError *error);
 
 
 #pragma mark * MSClientConnection Public Interface

--- a/sdk/iOS/src/MSClientInternal.h
+++ b/sdk/iOS/src/MSClientInternal.h
@@ -3,7 +3,8 @@
 // ----------------------------------------------------------------------------
 
 #import "MSClient.h"
-#import "MSSerializer.h"
+
+@protocol MSSerializer;
 
 @interface MSClient ()
 

--- a/sdk/iOS/src/MSCoreDataStore.m
+++ b/sdk/iOS/src/MSCoreDataStore.m
@@ -3,6 +3,7 @@
 // ----------------------------------------------------------------------------
 
 #import "MSCoreDataStore.h"
+#import "MSSyncContextReadResult.h"
 
 NSString *const SystemColumnPrefix = @"__";
 NSString *const StoreSystemColumnPrefix = @"ms_";

--- a/sdk/iOS/src/MSJSONSerializer.h
+++ b/sdk/iOS/src/MSJSONSerializer.h
@@ -5,7 +5,6 @@
 #import <Foundation/Foundation.h>
 #import "MSSerializer.h"
 
-
 #pragma mark * MSJSONSerializer Public Interface
 
 

--- a/sdk/iOS/src/MSLogin.h
+++ b/sdk/iOS/src/MSLogin.h
@@ -2,11 +2,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // ----------------------------------------------------------------------------
 
-#import <Foundation/Foundation.h>
-#import "MSClient.h"
-#import "MSLoginController.h"
-#import "MSLoginView.h"
-
+#import <UIKit/UIKit.h>
+#import "BlockDefinitions.h"
+@class MSClient;
+@class MSLoginController;
 
 #pragma mark * MSLogin Public Interface
 

--- a/sdk/iOS/src/MSLogin.m
+++ b/sdk/iOS/src/MSLogin.m
@@ -6,7 +6,9 @@
 #import "MSLoginSerializer.h"
 #import "MSJSONSerializer.h"
 #import "MSClientConnection.h"
-
+#import "MSLoginController.h"
+#import "MSUser.h"
+#import "MSClient.h"
 
 #pragma mark * MSLogin Private Interface
 

--- a/sdk/iOS/src/MSLoginController.h
+++ b/sdk/iOS/src/MSLoginController.h
@@ -3,16 +3,10 @@
 // ----------------------------------------------------------------------------
 
 #import <UIKit/UIKit.h>
+#import "BlockDefinitions.h"
 
 @class MSClient;
 @class MSUser;
-
-
-#pragma mark * Block Type Definitions
-
-/// Callback logging in an end user. If there was an error or the login was
-/// cancelled, *error* will be non-nil.
-typedef void (^MSClientLoginBlock)(MSUser *user, NSError *error);
 
 #pragma  mark * MSLoginController Public Interface
 

--- a/sdk/iOS/src/MSLoginController.m
+++ b/sdk/iOS/src/MSLoginController.m
@@ -6,7 +6,8 @@
 #import "MSLoginView.h"
 #import "MSLoginSerializer.h"
 #import "MSJSONSerializer.h"
-
+#import "MSSerializer.h"
+#import "MSClient.h"
 
 #pragma mark * MSLoginController Private Interface
 

--- a/sdk/iOS/src/MSLoginSerializer.h
+++ b/sdk/iOS/src/MSLoginSerializer.h
@@ -3,8 +3,8 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSUser.h"
 
+@class MSUser;
 
 #pragma mark * MSLoginSerializer Public Interface
 

--- a/sdk/iOS/src/MSLoginSerializer.m
+++ b/sdk/iOS/src/MSLoginSerializer.m
@@ -4,6 +4,7 @@
 
 #import "MSLoginSerializer.h"
 #import "MSError.h"
+#import "MSUser.h"
 
 
 #pragma mark * MSLoginSerializer Implementation

--- a/sdk/iOS/src/MSLoginView.h
+++ b/sdk/iOS/src/MSLoginView.h
@@ -3,8 +3,8 @@
 // ----------------------------------------------------------------------------
 
 #import <UIKit/UIKit.h>
-#import "MSClient.h"
 
+@class MSClient;
 
 #pragma mark * MSLoginViewErrorDomain
 

--- a/sdk/iOS/src/MSLoginView.m
+++ b/sdk/iOS/src/MSLoginView.m
@@ -4,7 +4,7 @@
 
 #import "MSLoginView.h"
 #import "MSClientConnection.h"
-
+#import "MSClient.h"
 
 #pragma mark * MSLoginViewErrorDomain
 

--- a/sdk/iOS/src/MSOperationQueue.h
+++ b/sdk/iOS/src/MSOperationQueue.h
@@ -3,8 +3,10 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSTableOperation.h"
-#import "MSClient.h"
+
+@class MSClient;
+@class MSTableOperation;
+@protocol MSSyncContextDataSource;
 
 /// A simple queue interface to abstract access from implementation. For now this may just
 /// be an NSArray but long term this is liable to change

--- a/sdk/iOS/src/MSOperationQueue.m
+++ b/sdk/iOS/src/MSOperationQueue.m
@@ -7,6 +7,8 @@
 #import "MSTable.h"
 #import "MSTableOperationInternal.h"
 #import "MSQuery.h"
+#import "MSSyncTable.h"
+#import "MSSyncContextReadResult.h"
 
 @interface MSOperationQueue()
 @property (nonatomic, weak) id<MSSyncContextDataSource> dataSource;

--- a/sdk/iOS/src/MSPush.h
+++ b/sdk/iOS/src/MSPush.h
@@ -3,7 +3,9 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSClient.h"
+#import "BlockDefinitions.h"
+
+@class MSClient;
 
 #pragma  mark * MSClient Public Interface
 

--- a/sdk/iOS/src/MSPush.m
+++ b/sdk/iOS/src/MSPush.m
@@ -5,6 +5,7 @@
 #import "MSPush.h"
 #import "MSRegistrationManager.h"
 #import "MSLocalStorage.h"
+#import "MSError.h"
 
 @interface MSPush ()
 @property (nonatomic, strong, readonly) MSRegistrationManager *registrationManager;

--- a/sdk/iOS/src/MSPushHttp.h
+++ b/sdk/iOS/src/MSPushHttp.h
@@ -3,11 +3,10 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSClientConnection.h"
-#import "MSPush.h"
+#import "BlockDefinitions.h"
 
-typedef void (^MSCreateRegistrationIdBlock)(NSString *registrationId, NSError *error);
-typedef void (^MSListRegistrationsBlock)(NSArray *registrations, NSError *error);
+@class MSClient;
+@class MSClientConnection;
 
 @interface MSPushHttp : NSObject
 

--- a/sdk/iOS/src/MSPushHttp.m
+++ b/sdk/iOS/src/MSPushHttp.m
@@ -5,6 +5,8 @@
 #import "MSPushRequest.h"
 #import "MSPushHttp.h"
 #import "MSClientInternal.h"
+#import "BlockDefinitions.h"
+#import "MSClientConnection.h"
 
 @interface MSPushHttp ()
 @property (nonatomic, weak, readonly) MSClient *client;

--- a/sdk/iOS/src/MSPushRequest.h
+++ b/sdk/iOS/src/MSPushRequest.h
@@ -3,7 +3,6 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSClient.h"
 
 @interface MSPushRequest : NSMutableURLRequest
 

--- a/sdk/iOS/src/MSQuery.h
+++ b/sdk/iOS/src/MSQuery.h
@@ -3,8 +3,10 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSTable.h"
-#import "MSSyncTable.h"
+#import "BlockDefinitions.h"
+
+@class MSSyncTable;
+@class MSTable;
 
 #pragma mark * MSQuery Public Interface
 

--- a/sdk/iOS/src/MSQuery.m
+++ b/sdk/iOS/src/MSQuery.m
@@ -7,6 +7,8 @@
 #import "MSURLBuilder.h"
 #import "MSSyncContextInternal.h"
 #import "MSTableInternal.h"
+#import "MSSyncTable.h"
+#import "MSClientInternal.h"
 
 #pragma mark * MSQuery Implementation
 

--- a/sdk/iOS/src/MSQueuePullOperation.h
+++ b/sdk/iOS/src/MSQueuePullOperation.h
@@ -3,7 +3,9 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSSyncContext.h"
+#import "BlockDefinitions.h"
+@class MSSyncContext;
+@class MSQuery;
 
 @interface MSQueuePullOperation : NSOperation {
     BOOL executing_;

--- a/sdk/iOS/src/MSQueuePullOperation.m
+++ b/sdk/iOS/src/MSQueuePullOperation.m
@@ -15,6 +15,11 @@
 #import "MSNaiveISODateFormatter.h"
 #import "MSDateOffset.h"
 #import "MSTableConfigValue.h"
+#import "MSQueryResult.h"
+#import "MSSyncTable.h"
+#import "MSSyncContextReadResult.h"
+#import "MSTable.h"
+#import "MSOperationQueue.h"
 
 @interface MSQueuePullOperation()
 

--- a/sdk/iOS/src/MSQueuePurgeOperation.h
+++ b/sdk/iOS/src/MSQueuePurgeOperation.h
@@ -3,8 +3,9 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSSyncContext.h"
-#import "MSSyncTable.h"
+#import "BlockDefinitions.h"
+@class MSQuery;
+@class MSSyncContext;
 
 @interface MSQueuePurgeOperation : NSOperation {
     BOOL executing_;

--- a/sdk/iOS/src/MSQueuePurgeOperation.m
+++ b/sdk/iOS/src/MSQueuePurgeOperation.m
@@ -13,6 +13,8 @@
 #import "MSClientInternal.h"
 #import "MSQueryInternal.h"
 #import "MSTableConfigValue.h"
+#import "MSOperationQueue.h"
+#import "MSSyncTable.h"
 
 @interface MSQueuePurgeOperation()
 

--- a/sdk/iOS/src/MSQueuePushOperation.h
+++ b/sdk/iOS/src/MSQueuePushOperation.h
@@ -3,7 +3,9 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSSyncContext.h"
+#import "BlockDefinitions.h"
+
+@class MSSyncContext;
 
 /// Performs all actions associated with a push operation including, sending each operation to
 /// the server, processing errors, and triggering the appropriate calls to the delegate, datasource,

--- a/sdk/iOS/src/MSQueuePushOperation.m
+++ b/sdk/iOS/src/MSQueuePushOperation.m
@@ -8,6 +8,10 @@
 #import "MSClientInternal.h"
 #import "MSTableOperationInternal.h"
 #import "MSQuery.h"
+#import "MSSerializer.h"
+#import "MSSyncTable.h"
+#import "MSSyncContextReadResult.h"
+#import "MSOperationQueue.h"
 
 @interface MSQueuePushOperation()
 

--- a/sdk/iOS/src/MSRegistrationManager.h
+++ b/sdk/iOS/src/MSRegistrationManager.h
@@ -3,7 +3,9 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSClient.h"
+#import "BlockDefinitions.h"
+
+@class MSClient;
 
 /// MSRegistrationManager orchestrates the steps of registering and unregistering.
 /// Its goal is to ensure that registrations are never duplicated and that

--- a/sdk/iOS/src/MSRegistrationManager.m
+++ b/sdk/iOS/src/MSRegistrationManager.m
@@ -5,6 +5,7 @@
 #import "MSRegistrationManager.h"
 #import "MSLocalStorage.h"
 #import "MSPushHttp.h"
+#import "MSClient.h"
 
 @interface MSRegistrationManager ()
 @property (nonatomic, strong, readonly) MSLocalStorage *storage;

--- a/sdk/iOS/src/MSSyncContext.h
+++ b/sdk/iOS/src/MSSyncContext.h
@@ -3,20 +3,12 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSTableOperation.h"
-#import "MSSyncContextReadResult.h"
+#import "BlockDefinitions.h"
 
 @class MSQuery;
 @class MSSyncContext;
-
-/// Callback for updates and deletes. If there was an error, the *error* will be non-nil.
-typedef void (^MSSyncBlock)(NSError *error);
-
-/// Callback for inserts. If there was an error, the *error* will be non-nil.
-typedef void (^MSSyncItemBlock)(NSDictionary *item, NSError *error);
-
-/// Callback for push operations
-typedef void (^MSSyncPushCompletionBlock)(void);
+@class MSTableOperation;
+@class MSSyncContextReadResult;
 
 /// The MSSyncContextDelegate allows for customizing the handling of errors, conflicts, and other
 /// conditions that may occur when syncing data between the device and the mobile service.

--- a/sdk/iOS/src/MSSyncContext.m
+++ b/sdk/iOS/src/MSSyncContext.m
@@ -16,6 +16,11 @@
 #import "MSNaiveISODateFormatter.h"
 #import "MSDateOffset.h"
 #import "MSTableConfigValue.h"
+#import "MSQueryResult.h"
+#import "MSSyncContextReadResult.h"
+#import "MSOperationQueue.h"
+#import "MSSyncTable.h"
+#import "MSSerializer.h"
 
 @implementation MSSyncContext {
     dispatch_queue_t writeOperationQueue;

--- a/sdk/iOS/src/MSSyncContextInternal.h
+++ b/sdk/iOS/src/MSSyncContextInternal.h
@@ -3,9 +3,15 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSClient.h"
-#import "MSOperationQueue.h"
-#import "MSTable.h"
+#import "MSSyncContext.h"
+#import "BlockDefinitions.h"
+#import "MSTableOperation.h"
+
+@class MSClient;
+@class MSOperationQueue;
+@class MSTable;
+@class MSTableOperation;
+@class MSSyncTable;
 
 @interface MSSyncContext()
 

--- a/sdk/iOS/src/MSSyncTable.h
+++ b/sdk/iOS/src/MSSyncTable.h
@@ -3,8 +3,11 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSClient.h"
-#import "MSTable.h"
+#import "BlockDefinitions.h"
+
+@class MSClient;
+@class MSTable;
+@class MSQuery;
 
 /// The *MSSyncTable* class represents a table of a Windows Azure Mobile Service.
 /// Items can be inserted, updated, deleted and read from the table. The table

--- a/sdk/iOS/src/MSTable.h
+++ b/sdk/iOS/src/MSTable.h
@@ -3,30 +3,10 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSClient.h"
-#import "MSQueryResult.h"
+#import "BlockDefinitions.h"
 
+@class MSClient;
 @class MSQuery;
-
-#pragma mark * Block Type Definitions
-
-/// Callback for updates, inserts or readWithId requests. If there was an
-/// error, the *error* will be non-nil.
-typedef void (^MSItemBlock)(NSDictionary *item, NSError *error);
-
-/// Callback for deletes. If there was an error, the *error* will be non-nil.
-typedef void (^MSDeleteBlock)(id itemId, NSError *error);
-
-/// Callback for reads. If there was an error, the *error* will be non-nil. If
-/// there was not an error, then the result will always be non-nil
-/// but but items may be empty if the query returned no results. If the query included a
-/// request for the total count of items on the server (not just those returned
-/// in *items* array), the *totalCount* in the result will have this value; otherwise
-/// *totalCount* will be -1.
-/// if the server returned a link to next page of results then
-/// nextLink will be non-nil.
-typedef void (^MSReadQueryBlock)(MSQueryResult *result,
-                                 NSError *error);
 
 typedef NS_OPTIONS(NSUInteger, MSSystemProperties) {
     MSSystemPropertyNone        = 0,

--- a/sdk/iOS/src/MSTableConnection.h
+++ b/sdk/iOS/src/MSTableConnection.h
@@ -4,8 +4,12 @@
 
 #import <Foundation/Foundation.h>
 #import "MSClientConnection.h"
-#import "MSTable.h"
-#import "MSTableRequest.h"
+
+@class MSTable;
+@class MSTableRequest;
+@class MSTableItemRequest;
+@class MSTableDeleteRequest;
+@class MSTableReadQueryRequest;
 
 #pragma  mark * MSTableConnection Public Interface
 

--- a/sdk/iOS/src/MSTableConnection.m
+++ b/sdk/iOS/src/MSTableConnection.m
@@ -6,6 +6,8 @@
 #import "MSSerializer.h"
 #import "MSQueryResult.h"
 #import "MSClientInternal.h"
+#import "MSTable.h"
+#import "MSTableRequest.h"
 
 // next link is the format "http://contoso.com; rel=next"
 static NSString *const nextLinkPattern = @"^(.*?);\\s*rel\\s*=\\s*(\\w+)\\s*"; // $1; rel = $2

--- a/sdk/iOS/src/MSTableOperation.h
+++ b/sdk/iOS/src/MSTableOperation.h
@@ -2,7 +2,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // ----------------------------------------------------------------------------
 
-#import "MSUser.h"
+#import <Foundation/Foundation.h>
+
+@class MSUser;
 
 /// The *MSTableOperation* object represents a pending operation that was created by an earlier
 /// call using the *MSSyncTable* object. This is a wrapper to facilitae sending the operation

--- a/sdk/iOS/src/MSTableOperation.m
+++ b/sdk/iOS/src/MSTableOperation.m
@@ -8,6 +8,7 @@
 #import "MSTable.h"
 #import "MSTableInternal.h"
 #import "MSJSONSerializer.h"
+#import "MSSerializer.h"
 
 @implementation MSTableOperation
 

--- a/sdk/iOS/src/MSTableOperationError.h
+++ b/sdk/iOS/src/MSTableOperationError.h
@@ -3,7 +3,11 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSSyncContext.h"
+#import "MSTableOperation.h"
+#import "BlockDefinitions.h"
+
+@class MSSyncContext;
+@class MSTableOperation;
 
 /// The *MSTableOperationError* class represents an error that occurred while sending a
 /// a table operation (insert, etc) to the Windows Azure Mobile Service during a sync

--- a/sdk/iOS/src/MSTableOperationError.m
+++ b/sdk/iOS/src/MSTableOperationError.m
@@ -7,6 +7,7 @@
 #import "MSError.h"
 #import "MSTableOperationInternal.h"
 #import "MSSyncContextInternal.h"
+#import "MSSerializer.h"
 
 @interface MSTableOperationError()
 

--- a/sdk/iOS/src/MSTableRequest.h
+++ b/sdk/iOS/src/MSTableRequest.h
@@ -3,7 +3,10 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSTable.h"
+#import "BlockDefinitions.h"
+
+@class MSTable;
+@class MSSDKFeatures;
 #import "MSSerializer.h"
 #import "MSSDKFeatures.h"
 

--- a/sdk/iOS/src/MSTableRequest.m
+++ b/sdk/iOS/src/MSTableRequest.m
@@ -6,6 +6,7 @@
 #import "MSURLBuilder.h"
 #import "MSSDKFeatures.h"
 #import "MSClientInternal.h"
+#import "MSTable.h"
 
 #pragma mark * HTTP Method String Constants
 

--- a/sdk/iOS/src/MSURLBuilder.h
+++ b/sdk/iOS/src/MSURLBuilder.h
@@ -3,10 +3,10 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSClient.h"
-#import "MSTable.h"
-#import "MSQuery.h"
 
+@class MSTable;
+@class MSQuery;
+@class MSClient;
 
 #pragma  mark * MSURLBuilder Public Interface
 

--- a/sdk/iOS/src/MSURLBuilder.m
+++ b/sdk/iOS/src/MSURLBuilder.m
@@ -4,7 +4,9 @@
 
 #import "MSURLBuilder.h"
 #import "MSPredicateTranslator.h"
-
+#import "MSTable.h"
+#import "MSClient.h"
+#import "MSQuery.h"
 
 #pragma mark * Query String Constants
 

--- a/sdk/iOS/src/WindowsAzureMobileServices.h
+++ b/sdk/iOS/src/WindowsAzureMobileServices.h
@@ -19,6 +19,10 @@
 #import "MSCoreDataStore.h"
 #import "MSPush.h"
 #import "MSDateOffset.h"
+#import "MSQueryResult.h"
+#import "MSSyncContextReadResult.h"
+#import "MSQuery.h"
+#import "MSOperationQueue.h"
 
 #define WindowsAzureMobileServicesSdkMajorVersion 2
 #define WindowsAzureMobileServicesSdkMinorVersion 1

--- a/sdk/iOS/test/MSSyncTableTests.m
+++ b/sdk/iOS/test/MSSyncTableTests.m
@@ -18,6 +18,7 @@
 #import "MSTableOperationError.h"
 #import "MSSyncContextInternal.h"
 #import "MSTableConfigValue.h"
+#import "WindowsAzureMobileServices.h"
 
 static NSString *const TodoTableNoVersion = @"TodoNoVersion";
 static NSString *const AllColumnTypesTable = @"ColumnTypes";

--- a/sdk/iOS/test/MSURLbuilderTests.m
+++ b/sdk/iOS/test/MSURLbuilderTests.m
@@ -5,6 +5,7 @@
 #import <XCTest/XCTest.h>
 #import "MSTable.h"
 #import "MSURLBuilder.h"
+#import "WindowsAzureMobileServices.h"
 
 @interface MSURLBuilderTests : XCTestCase
 

--- a/sdk/iOS/test/WindowsAzureMobileServicesFunctionalTests.m
+++ b/sdk/iOS/test/WindowsAzureMobileServicesFunctionalTests.m
@@ -6,6 +6,7 @@
 #import "WindowsAzureMobileServices.h"
 #import "MSTestFilter.h"
 #import "MSTable+MSTableTestUtilities.h"
+#import "WindowsAzureMobileServices.h"
 
 @interface WindowsAzureMobileServicesFunctionalTests : XCTestCase {
     MSClient *client;


### PR DESCRIPTION
Removing explicit #import in favour of @class declarations. Avoids import chaining when testing against a potential OS X implementation

Have built and run unit tests for iOS and all still succeeds. Further to this, I have created a target for an OS X project on my branch here: https://github.com/damienpontifex/azure-mobile-services/tree/OSX-target that requires these changes.

I have tested the further work from this PR to get an OS X target in a very basic application, just comparing authentication using ADAL for OS X and then passing the token into the mobile service. 

Would be very interested to get feedback and discussion, especially in an attempt to get this OS X support into the framework.