### PR TITLE
iOS: Fix handling of network errors on push

### DIFF
--- a/sdk/iOS/src/MSClientConnection.m
+++ b/sdk/iOS/src/MSClientConnection.m
@@ -52,7 +52,7 @@ static NSOperationQueue *delegateQueue;
 +(NSURLSession *)sessionWithDelegate:(id<NSURLSessionDelegate>)delegate delegateQueue:(NSOperationQueue *)queue
 {
 	NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
-	
+    
 	NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration
 											 delegate:delegate
 										delegateQueue:queue];

--- a/sdk/iOS/src/MSQueuePushOperation.m
+++ b/sdk/iOS/src/MSQueuePushOperation.m
@@ -183,9 +183,9 @@
                                                    code:MSPushAbortedAuthentication
                                           internalError:error];
             }
-            else if(error.domain == NSURLErrorDomain) {
+            else if ([error.domain isEqualToString:NSURLErrorDomain]) {
                 self.error = [self errorWithDescription:@"Push aborted due to network error"
-                                                   code:MSPushAbortedUnknown
+                                                   code:MSPushAbortedNetwork
                                           internalError:error];
             }
             else if (!didCondense) {

--- a/sdk/iOS/src/MSTableOperationError.h
+++ b/sdk/iOS/src/MSTableOperationError.h
@@ -35,6 +35,10 @@
 /// for a list of Mobile Service's error codes
 @property (nonatomic, readonly) NSInteger code;
 
+/// Represents the domain of the error recieved while executing the table operation, this will typically
+/// be the MSErrorDomain, but may differ if the delegate chooses to return other error types
+@property (nonatomic, readonly) NSString *domain;
+
 /// A description of what caused the operation to fail
 @property (nonatomic, readonly) NSString *description;
 

--- a/sdk/iOS/src/MSTableOperationError.m
+++ b/sdk/iOS/src/MSTableOperationError.m
@@ -14,6 +14,7 @@
 
 // Error
 @property (nonatomic) NSInteger code;
+@property (nonatomic) NSString *domain;
 
 @property (nonatomic) NSString *description;
 
@@ -53,6 +54,7 @@
     self = [self init];
     
     _code = error.code;
+    _domain = [error.domain copy];
     _description = [error.localizedDescription copy];
     
     NSHTTPURLResponse *response = [error.userInfo objectForKey:MSErrorResponseKey];
@@ -88,6 +90,7 @@
         NSDictionary *data = [serializer itemFromData:properties withOriginalItem:nil ensureDictionary:NO orError:nil];
         
         _code = [[data objectForKey:@"code"] integerValue];
+        _domain = [data objectForKey:@"domain"];
         _description = [data objectForKey:@"description"];
         _table = [data objectForKey:@"table"];
         _operation = [[data objectForKey:@"operation"] integerValue];
@@ -111,6 +114,7 @@
 {
     NSMutableDictionary *properties = [@{
             @"code": [NSNumber numberWithInteger:self.code],
+            @"domain": self.domain,
             @"description": self.description,
             @"table": self.table,
             @"operation": [NSNumber numberWithInteger:self.operation],

--- a/sdk/iOS/test/MSTableOperationErrorTests.m
+++ b/sdk/iOS/test/MSTableOperationErrorTests.m
@@ -64,6 +64,7 @@
     XCTAssertEqualObjects(opError.itemId, @"ABC");
     XCTAssertEqualObjects(opError.table, @"TodoItem");
     XCTAssertEqual(opError.code, MSErrorPreconditionFailed);
+    XCTAssertEqualObjects(opError.domain, MSErrorDomain);
     XCTAssertEqualObjects(opError.description, @"Insert error...");
 }
 
@@ -72,6 +73,7 @@
     NSDictionary *details = @{
         @"id": @"1-2-3",
         @"code": @MSErrorPreconditionFailed,
+        @"domain": MSErrorDomain,
         @"description": @"Insert error...",
         @"table": @"TodoItem",
         @"operation": [NSNumber numberWithInteger:MSTableOperationInsert],
@@ -94,6 +96,7 @@
     XCTAssertEqualObjects(opError.itemId, @"ABC");
     XCTAssertEqualObjects(opError.table, @"TodoItem");
     XCTAssertEqual(opError.code, MSErrorPreconditionFailed);
+    XCTAssertEqualObjects(opError.domain, MSErrorDomain);
     XCTAssertEqualObjects(opError.description, @"Insert error...");
 }
 


### PR DESCRIPTION
Internal error check for a fatal network condition was incorrect, causing all operations to be attempted (and no early abort).  Fixed check, and improved tracked internal error so if non MS owned errors occur, the push operation correctly lets the dev know that. 