### PR TITLE
Returning push and pull operations

### DIFF
--- a/sdk/iOS/src/MSSyncContext.h
+++ b/sdk/iOS/src/MSSyncContext.h
@@ -9,6 +9,7 @@
 @class MSSyncContext;
 @class MSTableOperation;
 @class MSSyncContextReadResult;
+@class MSQueuePushOperation;
 
 /// The MSSyncContextDelegate allows for customizing the handling of errors, conflicts, and other
 /// conditions that may occur when syncing data between the device and the mobile service.
@@ -101,7 +102,7 @@
 @property (nonatomic, readonly) NSUInteger pendingOperationsCount;
 
 /// Executes all current pending operations on the queue
-- (void) pushWithCompletion:(MSSyncBlock)completion;
+- (MSQueuePushOperation *) pushWithCompletion:(MSSyncBlock)completion;
 
 /// Specifies the delegate that will be used in the resolution of syncing issues
 @property (nonatomic, strong) id<MSSyncContextDelegate> delegate;

--- a/sdk/iOS/src/MSSyncContext.m
+++ b/sdk/iOS/src/MSSyncContext.m
@@ -87,7 +87,7 @@ static NSOperationQueue *pushQueue_;
 /// Begin sending pending operations to the remote tables. Abort the push attempt whenever any single operation
 /// recieves an error due to network or authorization. Otherwise operations will all run and all errors returned
 /// to the caller at once.
--(void) pushWithCompletion:(MSSyncBlock)completion
+-(MSQueuePushOperation *) pushWithCompletion:(MSSyncBlock)completion
 {
     // TODO: Allow users to cancel operations
     MSQueuePushOperation *push = [[MSQueuePushOperation alloc] initWithSyncContext:self
@@ -96,6 +96,8 @@ static NSOperationQueue *pushQueue_;
                                                                         completion:completion];
     
     [pushQueue_ addOperation:push];
+	
+	return push;
 }
 
 
@@ -326,7 +328,7 @@ static NSOperationQueue *pushQueue_;
 }
 
 /// Verify our input is valid and try to pull our data down from the server
-- (void) pullWithQuery:(MSQuery *)query queryId:(NSString *)queryId completion:(MSSyncBlock)completion;
+- (MSQueuePullOperation *) pullWithQuery:(MSQuery *)query queryId:(NSString *)queryId completion:(MSSyncBlock)completion;
 {
     // make a copy since we'll be modifying it internally
     MSQuery *queryCopy = [query copy];
@@ -376,7 +378,7 @@ static NSOperationQueue *pushQueue_;
                 completion(error);
             }];
         }
-        return;
+        return nil;
     }
     
     // Get the required system properties from the Store
@@ -409,48 +411,48 @@ static NSOperationQueue *pushQueue_;
     queryCopy.fetchLimit = MIN(maxRecords, defaultFetchLimit);
     
     // Begin the actual pull request
-    [self pullWithQueryInternal:queryCopy queryId:queryId maxRecords:maxRecords completion:completion];
+    return [self pullWithQueryInternal:queryCopy queryId:queryId maxRecords:maxRecords completion:completion];
 }
 
 /// Basic pull logic is:
 ///  Check if our table has pending operations, if so, push
 ///    If push fails, return error, else repeat while we have pending operations
 ///  Read from server using an MSQueuePullOperation
-- (void) pullWithQueryInternal:(MSQuery *)query queryId:(NSString *)queryId maxRecords:(NSInteger)maxRecords completion:(MSSyncBlock)completion
+- (MSQueuePullOperation *) pullWithQueryInternal:(MSQuery *)query queryId:(NSString *)queryId maxRecords:(NSInteger)maxRecords completion:(MSSyncBlock)completion
 {
-    dispatch_async(writeOperationQueue, ^{
-        // Before we can pull from the remote, we need to make sure out table doesn't having pending operations
-        NSArray *tableOps = [self.operationQueue getOperationsForTable:query.table.name item:nil];
-        if (tableOps.count > 0) {
-            [self pushWithCompletion:^(NSError *error) {
-                // For now we just abort the pull if the push failed to complete successfully
-                // Long term we can be smarter and check if our table succeeded
-                if (error) {
-                    if (completion) {
-                        [self.callbackQueue addOperationWithBlock:^{
-                            completion(error);
-                        }];
-                    }
-                } else {
-                    // Check again if we have new pending ops while we synced, and repeat as needed
-                    [self pullWithQueryInternal:query queryId:queryId maxRecords:maxRecords completion:completion];
-                }
-            }];
-            return;
-        } else {
-            // TODO: Allow users to cancel operations
-            MSQueuePullOperation *pull = [[MSQueuePullOperation alloc] initWithSyncContext:self
-                                                                                     query:query
-                                                                                   queryId:queryId
-                                                                                maxRecords:maxRecords
-                                                                             dispatchQueue:writeOperationQueue
-                                                                             callbackQueue:self.callbackQueue
-                                                                                completion:completion];
-            
-            
-            [pushQueue_ addOperation:pull];
-        }
-    });
+	MSQueuePullOperation *pull = [[MSQueuePullOperation alloc] initWithSyncContext:self
+																			 query:query
+																		   queryId:queryId
+																		maxRecords:maxRecords
+																	 dispatchQueue:writeOperationQueue
+																	 callbackQueue:self.callbackQueue
+																		completion:completion];
+	
+	// Before we can pull from the remote, we need to make sure out table doesn't having pending operations
+	NSArray *tableOps = [self.operationQueue getOperationsForTable:query.table.name item:nil];
+	if (tableOps.count > 0) {
+		MSQueuePushOperation *pushOperation = [self pushWithCompletion:^(NSError *error) {
+			// For now we just abort the pull if the push failed to complete successfully
+			// Long term we can be smarter and check if our table succeeded
+			if (error) {
+				if (completion) {
+					[pull cancel];
+					[self.callbackQueue addOperationWithBlock:^{
+						completion(error);
+					}];
+				}
+			} else {
+				[pushQueue_ addOperation:pull];
+				// Check again if we have new pending ops while we synced, and repeat as needed
+			}
+		}];
+		
+		[pull addDependency:pushOperation];
+	} else {
+		[pushQueue_ addOperation:pull];
+	}
+	
+	return pull;
 }
 
 /// In order to purge data from the local store, purge first checks if there are any pending operations for

--- a/sdk/iOS/src/MSSyncContextInternal.h
+++ b/sdk/iOS/src/MSSyncContextInternal.h
@@ -10,6 +10,8 @@
 @class MSOperationQueue;
 @class MSQuery;
 @class MSSyncTable;
+@class MSQueuePushOperation;
+@class MSQueuePullOperation;
 
 @interface MSSyncContext()
 
@@ -29,7 +31,7 @@
 
 -(void) readWithQuery:(MSQuery *)query completion:(MSReadQueryBlock)completion;
 
--(void) pullWithQuery:(MSQuery *)query queryId:(NSString *)queryId completion:(MSSyncBlock)completion;
+-(MSQueuePullOperation *) pullWithQuery:(MSQuery *)query queryId:(NSString *)queryId completion:(MSSyncBlock)completion;
 
 -(void) purgeWithQuery:(MSQuery *)query completion:(MSSyncBlock)completion;
 

--- a/sdk/iOS/src/MSSyncTable.h
+++ b/sdk/iOS/src/MSSyncTable.h
@@ -7,6 +7,7 @@
 
 @class MSClient;
 @class MSQuery;
+@class MSQueuePullOperation;
 
 /// The *MSSyncTable* class represents a table of a Windows Azure Mobile Service.
 /// Items can be inserted, updated, deleted and read from the table. The table
@@ -98,7 +99,7 @@
 /// MSQeury object.
 /// Before a pull is allowed to run, all pending requests on the specified table will be sent to
 /// the server. If a pending request for this table fails, the pull will be cancelled
--(void)pullWithQuery:(MSQuery *)query queryId:(NSString *)queryId completion:(MSSyncBlock)completion;
+-(MSQueuePullOperation *)pullWithQuery:(MSQuery *)query queryId:(NSString *)queryId completion:(MSSyncBlock)completion;
 
 /// Removes all records in the local cache that match the results of the specified query.
 /// If query is nil, all records in the local table will be removed.

--- a/sdk/iOS/src/MSSyncTable.m
+++ b/sdk/iOS/src/MSSyncTable.m
@@ -59,9 +59,9 @@
 #pragma mark * Public Local Storage Management commands
 
 
--(void)pullWithQuery:(MSQuery *)query queryId:(NSString *)queryId completion:(MSSyncBlock)completion
+-(MSQueuePullOperation *)pullWithQuery:(MSQuery *)query queryId:(NSString *)queryId completion:(MSSyncBlock)completion
 {
-    [self.client.syncContext pullWithQuery:query queryId:queryId completion:completion];
+    return [self.client.syncContext pullWithQuery:query queryId:queryId completion:completion];
 }
 
 -(void)purgeWithQuery:(MSQuery *)query completion:(MSSyncBlock)completion


### PR DESCRIPTION
The user can use the returned operations to cancel, or add as dependencies etc as per normal NSOperation usage.