### PR TITLE
initial work on annotating nullable types for better Swift compatibility

### DIFF
--- a/sdk/iOS/src/MSClient.h
+++ b/sdk/iOS/src/MSClient.h
@@ -143,19 +143,19 @@
 -(void)loginWithProvider:(nonnull NSString *)provider
               controller:(nonnull UIViewController *)controller
                 animated:(BOOL)animated
-              completion:(nonnull MSClientLoginBlock)completion;
+              completion:(nullable MSClientLoginBlock)completion;
 
 /// Returns an MSLoginController that can be used to log in the current
 /// end user with the given provider.
 -(nonnull MSLoginController *)loginViewControllerWithProvider:(nonnull NSString *)provider
-                                 completion:(nonnull MSClientLoginBlock)completion;
+                                 completion:(nullable MSClientLoginBlock)completion;
 #endif
 
 /// Logs in the current end user with the given provider and the given token for
 /// the provider.
 -(void)loginWithProvider:(nonnull NSString *)provider
                    token:(nonnull NSDictionary *)token
-              completion:(nonnull MSClientLoginBlock)completion;
+              completion:(nullable MSClientLoginBlock)completion;
 
 /// Logs out the current end user.
 -(void)logout;
@@ -169,10 +169,6 @@
 
 /// Returns an MSTable instance for a table with the given name.
 -(nonnull MSTable *)tableWithName:(nonnull NSString *)tableName;
-
-/// Old method to return an MSTable instance for a table with the given name.
-/// This has been deprecated. Use tableWithName:
--(nonnull MSTable *)getTable:(nonnull NSString *)tableName __deprecated;
 
 /// Returns an MSSyncTable instance for a table with the given name.
 -(nonnull MSSyncTable *)syncTableWithName:(nonnull NSString *)tableName;
@@ -188,7 +184,7 @@
 /// response content will be treated as JSON.
 -(void)invokeAPI:(nonnull NSString *)APIName
             body:(nullable id)body
-      HTTPMethod:(nonnull NSString *)method
+      HTTPMethod:(nullable NSString *)method
       parameters:(nullable NSDictionary *)parameters
          headers:(nullable NSDictionary *)headers
       completion:(nullable MSAPIBlock)completion;
@@ -197,7 +193,7 @@
 /// response content can be of any media type.
 -(void)invokeAPI:(nonnull NSString *)APIName
             data:(nullable NSData *)data
-      HTTPMethod:(nonnull NSString *)method
+      HTTPMethod:(nullable NSString *)method
       parameters:(nullable NSDictionary *)parameters
          headers:(nullable NSDictionary *)headers
       completion:(nullable MSAPIDataBlock)completion;

--- a/sdk/iOS/src/MSClient.h
+++ b/sdk/iOS/src/MSClient.h
@@ -34,10 +34,10 @@
 /// @{
 
 /// The URL of the Microsoft Azure Mobile App
-@property (nonatomic, strong, readonly) NSURL *applicationURL;
+@property (nonatomic, strong, readonly, nonnull) NSURL *applicationURL;
 
 /// The URL of the gateway associated with the mobile app
-@property (nonatomic, strong, readonly) NSURL *gatewayURL;
+@property (nonatomic, strong, readonly, nullable) NSURL *gatewayURL;
 
 /// The application key for the Microsoft Azure Mobile Service associated with
 /// the client if one was provided in the creation of the client and nil
@@ -45,22 +45,22 @@
 /// made to the Microsoft Azure Mobile Service, allowing the client to perform
 /// all actions on the Microsoft Azure Mobile Service that require application-key
 /// level permissions.
-@property (nonatomic, copy, readonly) NSString *applicationKey;
+@property (nonatomic, copy, readonly, nullable) NSString *applicationKey;
 
 /// A collection of MSFilter instances to apply to use with the requests and
 /// responses sent and received by the client. The property is readonly and the
 /// array is not-mutable. To apply a filter to a client, use the withFilter:
 /// method.
-@property (nonatomic, strong, readonly) NSArray *filters;
+@property (nonatomic, strong, readonly, nullable) NSArray *filters;
 
 /// A sync context that defines how offline data is synced and allows for manually
 /// syncing data on demand
-@property (nonatomic, strong)     MSSyncContext *syncContext;
+@property (nonatomic, strong, nullable)     MSSyncContext *syncContext;
 
 /// @name Registering and unregistering for push notifications
 
 /// The property to use for registering and unregistering for notifications via *MSPush*.
-@property (nonatomic, strong, readonly) MSPush *push;
+@property (nonatomic, strong, readonly, nullable) MSPush *push;
 
 /// @}
 
@@ -70,7 +70,7 @@
 /// The currently logged in user. While the currentUser property can be set
 /// directly, the login* and logout methods are more convenient and
 /// recommended for non-testing use.
-@property (nonatomic, strong) MSUser *currentUser;
+@property (nonatomic, strong, nullable) MSUser *currentUser;
 
 /// @}
 
@@ -80,55 +80,55 @@
 /// @{
 
 /// Creates a client with the given URL for the Microsoft Azure Mobile Service.
-+(MSClient *)clientWithApplicationURLString:(NSString *)urlString;
++(nonnull MSClient *)clientWithApplicationURLString:(nonnull NSString *)urlString;
 
 /// Creates a client with the given URL and application key for the Microsoft Azure
 /// Mobile Service.
-+(MSClient *)clientWithApplicationURLString:(NSString *)urlString
-                         applicationKey:(NSString *)key;
++(nonnull MSClient *)clientWithApplicationURLString:(nonnull NSString *)urlString
+                         applicationKey:(nullable NSString *)key;
 
 /// Creates a client with the given URL and application key for the Microsoft Azure
 /// Mobile Service.
-+(MSClient *)clientWithApplicationURLString:(NSString *)applicationUrlString
-                           gatewayURLString:(NSString *)gatewayUrlString
-                             applicationKey:(NSString *)key;
++(nonnull MSClient *)clientWithApplicationURLString:(nonnull NSString *)applicationUrlString
+                           gatewayURLString:(nullable NSString *)gatewayUrlString
+                             applicationKey:(nullable NSString *)key;
 
 
 /// Creates a client with the given URL for the Microsoft Azure Mobile Service.
-+(MSClient *)clientWithApplicationURL:(NSURL *)url;
++(nonnull MSClient *)clientWithApplicationURL:(nonnull NSURL *)url;
 
 /// Creates a client with the given URL and application key for the Microsoft Azure
 /// Mobile Service.
-+(MSClient *)clientWithApplicationURL:(NSURL *)url
-                       applicationKey:(NSString *)key;
++(nonnull MSClient *)clientWithApplicationURL:(nonnull NSURL *)url
+                       applicationKey:(nullable NSString *)key;
 
 /// Creates a client with the given URL and application key for the Microsoft Azure
 /// Mobile Service.
-+(MSClient *)clientWithApplicationURL:(NSURL *)applicationUrl
-                           gatewayURL:(NSURL *)gatewayUrl
-                       applicationKey:(NSString *)key;
++(nonnull MSClient *)clientWithApplicationURL:(nonnull NSURL *)applicationUrl
+                           gatewayURL:(nullable NSURL *)gatewayUrl
+                       applicationKey:(nullable NSString *)key;
 
 
 #pragma  mark * Public Initializer Methods
 
 /// Initializes a client with the given URL for the Microsoft Azure Mobile Service.
--(id)initWithApplicationURL:(NSURL *)url;
+-(nonnull instancetype)initWithApplicationURL:(nonnull NSURL *)url;
 
 /// Initializes a client with the given URL and application key for the Windows
 /// Azure Mobile Service.
--(id)initWithApplicationURL:(NSURL *)url applicationKey:(NSString *)key;
+-(nonnull instancetype)initWithApplicationURL:(nonnull NSURL *)url applicationKey:(nullable NSString *)key;
 
 /// Initializes a client with the given URL and application key for the Windows
 /// Azure Mobile Service.
--(id)initWithApplicationURL:(NSURL *)applicationUrl
-                 gatewayURL:(NSURL *)gatewayUrl
-             applicationKey:(NSString *)key;
+-(nonnull instancetype)initWithApplicationURL:(nonnull NSURL *)applicationUrl
+                 gatewayURL:(nullable NSURL *)gatewayUrl
+             applicationKey:(nullable NSString *)key;
 
 
 #pragma mark * Public Filter Methods
 
 /// Creates a clone of the client with the given filter applied to the new client.
--(MSClient *)clientWithFilter:(id<MSFilter>)filter;
+-(nonnull MSClient *)clientWithFilter:(nonnull id<MSFilter>)filter;
 
 ///@}
 
@@ -140,22 +140,22 @@
 #if TARGET_OS_IPHONE
 /// Logs in the current end user with the given provider by presenting the
 /// MSLoginController with the given controller.
--(void)loginWithProvider:(NSString *)provider
-              controller:(UIViewController *)controller
+-(void)loginWithProvider:(nonnull NSString *)provider
+              controller:(nonnull UIViewController *)controller
                 animated:(BOOL)animated
-              completion:(MSClientLoginBlock)completion;
+              completion:(nonnull MSClientLoginBlock)completion;
 
 /// Returns an MSLoginController that can be used to log in the current
 /// end user with the given provider.
--(MSLoginController *)loginViewControllerWithProvider:(NSString *)provider
-                                 completion:(MSClientLoginBlock)completion;
+-(nonnull MSLoginController *)loginViewControllerWithProvider:(nonnull NSString *)provider
+                                 completion:(nonnull MSClientLoginBlock)completion;
 #endif
 
 /// Logs in the current end user with the given provider and the given token for
 /// the provider.
--(void)loginWithProvider:(NSString *)provider
-                   token:(NSDictionary *)token
-              completion:(MSClientLoginBlock)completion;
+-(void)loginWithProvider:(nonnull NSString *)provider
+                   token:(nonnull NSDictionary *)token
+              completion:(nonnull MSClientLoginBlock)completion;
 
 /// Logs out the current end user.
 -(void)logout;
@@ -168,14 +168,14 @@
 /// @{
 
 /// Returns an MSTable instance for a table with the given name.
--(MSTable *)tableWithName:(NSString *)tableName;
+-(nonnull MSTable *)tableWithName:(nonnull NSString *)tableName;
 
 /// Old method to return an MSTable instance for a table with the given name.
 /// This has been deprecated. Use tableWithName:
--(MSTable *)getTable:(NSString *)tableName __deprecated;
+-(nonnull MSTable *)getTable:(nonnull NSString *)tableName __deprecated;
 
 /// Returns an MSSyncTable instance for a table with the given name.
--(MSSyncTable *)syncTableWithName:(NSString *)tableName;
+-(nonnull MSSyncTable *)syncTableWithName:(nonnull NSString *)tableName;
 
 /// @}
 
@@ -186,21 +186,21 @@
 
 /// Invokes a user-defined API of the Mobile Service.  The HTTP request and
 /// response content will be treated as JSON.
--(void)invokeAPI:(NSString *)APIName
-            body:(id)body
-      HTTPMethod:(NSString *)method
-      parameters:(NSDictionary *)parameters
-         headers:(NSDictionary *)headers
-      completion:(MSAPIBlock)completion;
+-(void)invokeAPI:(nonnull NSString *)APIName
+            body:(nullable id)body
+      HTTPMethod:(nonnull NSString *)method
+      parameters:(nullable NSDictionary *)parameters
+         headers:(nullable NSDictionary *)headers
+      completion:(nullable MSAPIBlock)completion;
 
 /// Invokes a user-defined API of the Mobile Service.  The HTTP request and
 /// response content can be of any media type.
--(void)invokeAPI:(NSString *)APIName
-            data:(NSData *)data
-      HTTPMethod:(NSString *)method
-      parameters:(NSDictionary *)parameters
-         headers:(NSDictionary *)headers
-      completion:(MSAPIDataBlock)completion;
+-(void)invokeAPI:(nonnull NSString *)APIName
+            data:(nullable NSData *)data
+      HTTPMethod:(nonnull NSString *)method
+      parameters:(nullable NSDictionary *)parameters
+         headers:(nullable NSDictionary *)headers
+      completion:(nullable MSAPIDataBlock)completion;
 
 /// @}
 
@@ -213,7 +213,7 @@
 
 /// Determines where connections made to the mobile service are run. If set, connection related
 /// logic will occur on this queue. Otherwise, the thread that made the call will be used.
-@property (nonatomic, strong) NSOperationQueue *connectionDelegateQueue;
+@property (nonatomic, strong, nullable) NSOperationQueue *connectionDelegateQueue;
 
 /// @}
 


### PR DESCRIPTION
Adding nullability annotations to MSClient relating to #669 . Only added to this class as a first stage and to receive feedback on these initial annotations and their usage.

I have run trials with this in my own Swift application and they seem be valid null/nonnull parameters. If these seem good and are accepted, can continue to markup other public classes in this trend.