### PR TITLE
Make Id column operations case insensitive

### DIFF
--- a/sdk/iOS/src/MSCoreDataStore.m
+++ b/sdk/iOS/src/MSCoreDataStore.m
@@ -53,7 +53,7 @@ NSString *const StoreDeleted = @"ms_deleted";
     NSFetchRequest *fr = [[NSFetchRequest alloc] init];
     [fr setEntity:entity];
     
-    fr.predicate = [NSPredicate predicateWithFormat:@"%K == %@", MSSystemColumnId, itemId];
+    fr.predicate = [NSPredicate predicateWithFormat:@"%K ==[c] %@", MSSystemColumnId, itemId];
     
     if (asDictionary) {
         fr.resultType = NSDictionaryResultType;

--- a/sdk/iOS/src/MSOperationQueue.m
+++ b/sdk/iOS/src/MSOperationQueue.m
@@ -60,7 +60,7 @@
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:syncTable];
     
     if (item) {
-        query.predicate = [NSPredicate predicateWithFormat:@"(table == %@) AND (itemId == %@)", table, item];
+        query.predicate = [NSPredicate predicateWithFormat:@"(table == %@) AND (itemId ==[c] %@)", table, item];
     } else {
         query.predicate = [NSPredicate predicateWithFormat:@"(table == %@)", table];
     }

--- a/sdk/iOS/src/MSQueuePullOperation.m
+++ b/sdk/iOS/src/MSQueuePullOperation.m
@@ -188,7 +188,7 @@
                     isDeleted = ((NSNumber *)isDeletedObj).boolValue;
                 }
                 
-                NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K == %@", @"itemId", obj[MSSystemColumnId]];
+                NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K ==[c] %@", @"itemId", obj[MSSystemColumnId]];
                 NSArray *matchingRecords = [pendingOps filteredArrayUsingPredicate:predicate];
                 
                 // we want to ignore items that have been touched since the Pull was started


### PR DESCRIPTION
- Round tripping a GUID generated on iOS via the server (managed) results in the server pushing down a record with ID in a different case. Making ID comparisons case insensitive fixes bugs related to this.