### PR TITLE
[iOS] Returning operations from sync actions

### DIFF
--- a/sdk/iOS/WindowsAzureMobileServices.xcodeproj/project.pbxproj
+++ b/sdk/iOS/WindowsAzureMobileServices.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		E8F33B3D1616694C002DD7C6 /* MSQueryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E8F33B3A161668ED002DD7C6 /* MSQueryTests.m */; };
 		E8F33B3E16166956002DD7C6 /* MSJSONSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E8F33B36161668DA002DD7C6 /* MSJSONSerializerTests.m */; };
 		E8F33B3F1616695E002DD7C6 /* MSPredicateTranslatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E8F33B38161668E4002DD7C6 /* MSPredicateTranslatorTests.m */; };
+		F3EA41DD1B0E63470014B587 /* MSQueuePullOperationInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = F3EA41DC1B0E62F40014B587 /* MSQueuePullOperationInternal.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -300,6 +301,7 @@
 		E8F33B36161668DA002DD7C6 /* MSJSONSerializerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSJSONSerializerTests.m; sourceTree = "<group>"; };
 		E8F33B38161668E4002DD7C6 /* MSPredicateTranslatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSPredicateTranslatorTests.m; sourceTree = "<group>"; };
 		E8F33B3A161668ED002DD7C6 /* MSQueryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSQueryTests.m; sourceTree = "<group>"; };
+		F3EA41DC1B0E62F40014B587 /* MSQueuePullOperationInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSQueuePullOperationInternal.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -375,6 +377,7 @@
 				A25888FC18A19D0B00962F9A /* MSOperationQueue.h */,
 				A25888FD18A19D0B00962F9A /* MSOperationQueue.m */,
 				CF4D49851A2E5C96006AEB70 /* MSQueuePullOperation.h */,
+				F3EA41DC1B0E62F40014B587 /* MSQueuePullOperationInternal.h */,
 				CF4D49891A2E5CF8006AEB70 /* MSQueuePullOperation.m */,
 				CF1D745A1A5D85D80074789F /* MSQueuePurgeOperation.h */,
 				CF1D74581A5D85C60074789F /* MSQueuePurgeOperation.m */,
@@ -669,6 +672,7 @@
 				A2ACD540192322C50012B1ED /* MSCoreDataStore.h in Headers */,
 				CF762EC61A1D366E0018C292 /* MSDateOffset.h in Headers */,
 				A24701B9196896F500385DA2 /* MSPush.h in Headers */,
+				F3EA41DD1B0E63470014B587 /* MSQueuePullOperationInternal.h in Headers */,
 				870C0C9C199C246700A134DD /* MSSDKFeatures.h in Headers */,
 				E8E3790F161F769D00C13F00 /* MSError.h in Headers */,
 				A2C14C6A19105D9F00A58609 /* MSSyncContextReadResult.h in Headers */,

--- a/sdk/iOS/src/MSQueuePullOperationInternal.h
+++ b/sdk/iOS/src/MSQueuePullOperationInternal.h
@@ -1,0 +1,9 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+#import "MSQueuePullOperation.h"
+
+@interface MSQueuePullOperation ()
+- (void)completeOperation;
+@end

--- a/sdk/iOS/src/MSSyncContext.h
+++ b/sdk/iOS/src/MSSyncContext.h
@@ -110,7 +110,7 @@ typedef void (^MSSyncPushCompletionBlock)(void);
 @property (nonatomic, readonly) NSUInteger pendingOperationsCount;
 
 /// Executes all current pending operations on the queue
-- (MSQueuePushOperation *) pushWithCompletion:(MSSyncBlock)completion;
+- (NSOperation *) pushWithCompletion:(MSSyncBlock)completion;
 
 /// Specifies the delegate that will be used in the resolution of syncing issues
 @property (nonatomic, strong) id<MSSyncContextDelegate> delegate;

--- a/sdk/iOS/src/MSSyncContext.h
+++ b/sdk/iOS/src/MSSyncContext.h
@@ -8,6 +8,7 @@
 
 @class MSQuery;
 @class MSSyncContext;
+@class MSQueuePushOperation;
 
 /// Callback for updates and deletes. If there was an error, the *error* will be non-nil.
 typedef void (^MSSyncBlock)(NSError *error);
@@ -109,7 +110,7 @@ typedef void (^MSSyncPushCompletionBlock)(void);
 @property (nonatomic, readonly) NSUInteger pendingOperationsCount;
 
 /// Executes all current pending operations on the queue
-- (void) pushWithCompletion:(MSSyncBlock)completion;
+- (MSQueuePushOperation *) pushWithCompletion:(MSSyncBlock)completion;
 
 /// Specifies the delegate that will be used in the resolution of syncing issues
 @property (nonatomic, strong) id<MSSyncContextDelegate> delegate;

--- a/sdk/iOS/src/MSSyncContext.h
+++ b/sdk/iOS/src/MSSyncContext.h
@@ -8,7 +8,6 @@
 
 @class MSQuery;
 @class MSSyncContext;
-@class MSQueuePushOperation;
 
 /// Callback for updates and deletes. If there was an error, the *error* will be non-nil.
 typedef void (^MSSyncBlock)(NSError *error);

--- a/sdk/iOS/src/MSSyncContext.m
+++ b/sdk/iOS/src/MSSyncContext.m
@@ -82,7 +82,7 @@ static NSOperationQueue *pushQueue_;
 /// Begin sending pending operations to the remote tables. Abort the push attempt whenever any single operation
 /// recieves an error due to network or authorization. Otherwise operations will all run and all errors returned
 /// to the caller at once.
--(MSQueuePushOperation *) pushWithCompletion:(MSSyncBlock)completion
+-(NSOperation *) pushWithCompletion:(MSSyncBlock)completion
 {
     // TODO: Allow users to cancel operations
     MSQueuePushOperation *push = [[MSQueuePushOperation alloc] initWithSyncContext:self
@@ -431,13 +431,14 @@ static NSOperationQueue *pushQueue_;
 				// For now we just abort the pull if the push failed to complete successfully
 				// Long term we can be smarter and check if our table succeeded
 				if (error) {
+					[pull cancel];
+					
 					if (completion) {
 						[self.callbackQueue addOperationWithBlock:^{
 							completion(error);
 						}];
 					}
 				} else {
-					// Check again if we have new pending ops while we synced, and repeat as needed
 					[pushQueue_ addOperation:pull];
 				}
 			}];

--- a/sdk/iOS/src/MSSyncContext.m
+++ b/sdk/iOS/src/MSSyncContext.m
@@ -11,7 +11,7 @@
 #import "MSQuery.h"
 #import "MSQueryInternal.h"
 #import "MSQueuePushOperation.h"
-#import "MSQueuePullOperation.h"
+#import "MSQueuePullOperationInternal.h"
 #import "MSQueuePurgeOperation.h"
 #import "MSNaiveISODateFormatter.h"
 #import "MSDateOffset.h"
@@ -432,6 +432,7 @@ static NSOperationQueue *pushQueue_;
                 // Long term we can be smarter and check if our table succeeded
                 if (error) {
                     [pull cancel];
+					[pull completeOperation];
                     
                     if (completion) {
                         [self.callbackQueue addOperationWithBlock:^{

--- a/sdk/iOS/src/MSSyncContext.m
+++ b/sdk/iOS/src/MSSyncContext.m
@@ -91,8 +91,8 @@ static NSOperationQueue *pushQueue_;
                                                                         completion:completion];
     
     [pushQueue_ addOperation:push];
-	
-	return push;
+    
+    return push;
 }
 
 
@@ -415,41 +415,41 @@ static NSOperationQueue *pushQueue_;
 ///  Read from server using an MSQueuePullOperation
 - (NSOperation *) pullWithQueryInternal:(MSQuery *)query queryId:(NSString *)queryId maxRecords:(NSInteger)maxRecords completion:(MSSyncBlock)completion
 {
-	MSQueuePullOperation *pull = [[MSQueuePullOperation alloc] initWithSyncContext:self
-																			 query:query
-																		   queryId:queryId
-																		maxRecords:maxRecords
-																	 dispatchQueue:writeOperationQueue
-																	 callbackQueue:self.callbackQueue
-																		completion:completion];
-	
-	dispatch_async(writeOperationQueue, ^{
-		// Before we can pull from the remote, we need to make sure out table doesn't having pending operations
-		NSArray *tableOps = [self.operationQueue getOperationsForTable:query.table.name item:nil];
-		if (tableOps.count > 0) {
-			NSOperation *push = [self pushWithCompletion:^(NSError *error) {
-				// For now we just abort the pull if the push failed to complete successfully
-				// Long term we can be smarter and check if our table succeeded
-				if (error) {
-					[pull cancel];
-					
-					if (completion) {
-						[self.callbackQueue addOperationWithBlock:^{
-							completion(error);
-						}];
-					}
-				} else {
-					[pushQueue_ addOperation:pull];
-				}
-			}];
-			
-			[pull addDependency:push];
-		} else {
-			[pushQueue_ addOperation:pull];
-		}
-	});
-	
-	return pull;
+    MSQueuePullOperation *pull = [[MSQueuePullOperation alloc] initWithSyncContext:self
+                                                                             query:query
+                                                                           queryId:queryId
+                                                                        maxRecords:maxRecords
+                                                                     dispatchQueue:writeOperationQueue
+                                                                     callbackQueue:self.callbackQueue
+                                                                        completion:completion];
+    
+    dispatch_async(writeOperationQueue, ^{
+        // Before we can pull from the remote, we need to make sure out table doesn't having pending operations
+        NSArray *tableOps = [self.operationQueue getOperationsForTable:query.table.name item:nil];
+        if (tableOps.count > 0) {
+            NSOperation *push = [self pushWithCompletion:^(NSError *error) {
+                // For now we just abort the pull if the push failed to complete successfully
+                // Long term we can be smarter and check if our table succeeded
+                if (error) {
+                    [pull cancel];
+                    
+                    if (completion) {
+                        [self.callbackQueue addOperationWithBlock:^{
+                            completion(error);
+                        }];
+                    }
+                } else {
+                    [pushQueue_ addOperation:pull];
+                }
+            }];
+            
+            [pull addDependency:push];
+        } else {
+            [pushQueue_ addOperation:pull];
+        }
+    });
+    
+    return pull;
 }
 
 /// In order to purge data from the local store, purge first checks if there are any pending operations for
@@ -464,8 +464,8 @@ static NSOperationQueue *pushQueue_;
                                                                              callbackQueue:self.callbackQueue
                                                                                 completion:completion];
     [pushQueue_ addOperation:purge];
-	
-	return purge;
+    
+    return purge;
 }
 
 /// Purges all data, pending operations, operation errors, and metadata for the
@@ -480,8 +480,8 @@ static NSOperationQueue *pushQueue_;
                                                                              callbackQueue:self.callbackQueue
                                                                                 completion:completion];
     [pushQueue_ addOperation:purge];
-	
-	return purge;
+    
+    return purge;
 }
 
 + (BOOL) dictionary:(NSDictionary *)dictionary containsCaseInsensitiveKey:(NSString *)key

--- a/sdk/iOS/src/MSSyncContextInternal.h
+++ b/sdk/iOS/src/MSSyncContextInternal.h
@@ -29,11 +29,11 @@
 
 -(void) readWithQuery:(MSQuery *)query completion:(MSReadQueryBlock)completion;
 
--(MSQueuePullOperation *) pullWithQuery:(MSQuery *)query queryId:(NSString *)queryId completion:(MSSyncBlock)completion;
+-(NSOperation *) pullWithQuery:(MSQuery *)query queryId:(NSString *)queryId completion:(MSSyncBlock)completion;
 
--(MSQueuePurgeOperation *) purgeWithQuery:(MSQuery *)query completion:(MSSyncBlock)completion;
+-(NSOperation *) purgeWithQuery:(MSQuery *)query completion:(MSSyncBlock)completion;
 
--(MSQueuePurgeOperation *) forcePurgeWithTable:(MSSyncTable *)syncTable completion:(MSSyncBlock)completion;
+-(NSOperation *) forcePurgeWithTable:(MSSyncTable *)syncTable completion:(MSSyncBlock)completion;
 
 
 #pragma mark * Operation Helpers

--- a/sdk/iOS/src/MSSyncContextInternal.h
+++ b/sdk/iOS/src/MSSyncContextInternal.h
@@ -7,10 +7,6 @@
 #import "MSOperationQueue.h"
 #import "MSTable.h"
 
-@class MSQueuePushOperation;
-@class MSQueuePullOperation;
-@class MSQueuePurgeOperation;
-
 @interface MSSyncContext()
 
 @property (nonatomic, weak)             MSClient *client;

--- a/sdk/iOS/src/MSSyncContextInternal.h
+++ b/sdk/iOS/src/MSSyncContextInternal.h
@@ -7,6 +7,10 @@
 #import "MSOperationQueue.h"
 #import "MSTable.h"
 
+@class MSQueuePushOperation;
+@class MSQueuePullOperation;
+@class MSQueuePurgeOperation;
+
 @interface MSSyncContext()
 
 @property (nonatomic, weak)             MSClient *client;
@@ -25,11 +29,11 @@
 
 -(void) readWithQuery:(MSQuery *)query completion:(MSReadQueryBlock)completion;
 
--(void) pullWithQuery:(MSQuery *)query queryId:(NSString *)queryId completion:(MSSyncBlock)completion;
+-(MSQueuePullOperation *) pullWithQuery:(MSQuery *)query queryId:(NSString *)queryId completion:(MSSyncBlock)completion;
 
--(void) purgeWithQuery:(MSQuery *)query completion:(MSSyncBlock)completion;
+-(MSQueuePurgeOperation *) purgeWithQuery:(MSQuery *)query completion:(MSSyncBlock)completion;
 
--(void) forcePurgeWithTable:(MSSyncTable *)syncTable completion:(MSSyncBlock)completion;
+-(MSQueuePurgeOperation *) forcePurgeWithTable:(MSSyncTable *)syncTable completion:(MSSyncBlock)completion;
 
 
 #pragma mark * Operation Helpers

--- a/sdk/iOS/src/MSSyncTable.h
+++ b/sdk/iOS/src/MSSyncTable.h
@@ -97,8 +97,9 @@
 
 /// Initiates a request to go to the server and get a set of records matching the specified
 /// MSQeury object.
-/// Before a pull is allowed to run, all pending requests on the specified table will be sent to
-/// the server. If a pending request for this table fails, the pull will be cancelled
+/// Before a pull is allowed to run, one operation to send all pending requests on the
+/// specified table will be sent to the server. If a pending request for this table fails,
+/// the pull will be cancelled
 -(NSOperation *)pullWithQuery:(MSQuery *)query queryId:(NSString *)queryId completion:(MSSyncBlock)completion;
 
 /// Removes all records in the local cache that match the results of the specified query.

--- a/sdk/iOS/src/MSSyncTable.h
+++ b/sdk/iOS/src/MSSyncTable.h
@@ -6,6 +6,9 @@
 #import "MSClient.h"
 #import "MSTable.h"
 
+@class MSQueuePullOperation;
+@class MSQueuePurgeOperation;
+
 /// The *MSSyncTable* class represents a table of a Windows Azure Mobile Service.
 /// Items can be inserted, updated, deleted and read from the table. The table
 /// can also be queried to retrieve an array of items that meet the given query
@@ -96,17 +99,17 @@
 /// MSQeury object.
 /// Before a pull is allowed to run, all pending requests on the specified table will be sent to
 /// the server. If a pending request for this table fails, the pull will be cancelled
--(void)pullWithQuery:(MSQuery *)query queryId:(NSString *)queryId completion:(MSSyncBlock)completion;
+-(MSQueuePullOperation *)pullWithQuery:(MSQuery *)query queryId:(NSString *)queryId completion:(MSSyncBlock)completion;
 
 /// Removes all records in the local cache that match the results of the specified query.
 /// If query is nil, all records in the local table will be removed.
 /// Before local data is removed, a check will be made for pending operations on this table. If
 /// any are found the purge will be cancelled and an error returned.
--(void)purgeWithQuery:(MSQuery *)query completion:(MSSyncBlock)completion;
+-(MSQueuePurgeOperation *)purgeWithQuery:(MSQuery *)query completion:(MSSyncBlock)completion;
 
 /// Purges all data, pending operations, operation errors, and metadata for the
 /// MSSyncTable from the local cache.
--(void)forcePurgeWithCompletion:(MSSyncBlock)completion;
+-(MSQueuePurgeOperation *)forcePurgeWithCompletion:(MSSyncBlock)completion;
 
 /// @}
 

--- a/sdk/iOS/src/MSSyncTable.h
+++ b/sdk/iOS/src/MSSyncTable.h
@@ -99,17 +99,17 @@
 /// MSQeury object.
 /// Before a pull is allowed to run, all pending requests on the specified table will be sent to
 /// the server. If a pending request for this table fails, the pull will be cancelled
--(MSQueuePullOperation *)pullWithQuery:(MSQuery *)query queryId:(NSString *)queryId completion:(MSSyncBlock)completion;
+-(NSOperation *)pullWithQuery:(MSQuery *)query queryId:(NSString *)queryId completion:(MSSyncBlock)completion;
 
 /// Removes all records in the local cache that match the results of the specified query.
 /// If query is nil, all records in the local table will be removed.
 /// Before local data is removed, a check will be made for pending operations on this table. If
 /// any are found the purge will be cancelled and an error returned.
--(MSQueuePurgeOperation *)purgeWithQuery:(MSQuery *)query completion:(MSSyncBlock)completion;
+-(NSOperation *)purgeWithQuery:(MSQuery *)query completion:(MSSyncBlock)completion;
 
 /// Purges all data, pending operations, operation errors, and metadata for the
 /// MSSyncTable from the local cache.
--(MSQueuePurgeOperation *)forcePurgeWithCompletion:(MSSyncBlock)completion;
+-(NSOperation *)forcePurgeWithCompletion:(MSSyncBlock)completion;
 
 /// @}
 

--- a/sdk/iOS/src/MSSyncTable.m
+++ b/sdk/iOS/src/MSSyncTable.m
@@ -59,12 +59,12 @@
 #pragma mark * Public Local Storage Management commands
 
 
--(MSQueuePullOperation *)pullWithQuery:(MSQuery *)query queryId:(NSString *)queryId completion:(MSSyncBlock)completion
+-(NSOperation *)pullWithQuery:(MSQuery *)query queryId:(NSString *)queryId completion:(MSSyncBlock)completion
 {
     return [self.client.syncContext pullWithQuery:query queryId:queryId completion:completion];
 }
 
--(MSQueuePurgeOperation *)purgeWithQuery:(MSQuery *)query completion:(MSSyncBlock)completion
+-(NSOperation *)purgeWithQuery:(MSQuery *)query completion:(MSSyncBlock)completion
 {
     // If no query, purge all records in the table by default
     if (query == nil) {
@@ -78,7 +78,7 @@
 
 /// Purges all data, pending operations, operation errors, and metadata for the
 /// MSSyncTable from the local store.
--(MSQueuePurgeOperation *)forcePurgeWithCompletion:(MSSyncBlock)completion
+-(NSOperation *)forcePurgeWithCompletion:(MSSyncBlock)completion
 {
     return [self.client.syncContext forcePurgeWithTable:self completion:completion];
 }

--- a/sdk/iOS/src/MSSyncTable.m
+++ b/sdk/iOS/src/MSSyncTable.m
@@ -59,28 +59,28 @@
 #pragma mark * Public Local Storage Management commands
 
 
--(void)pullWithQuery:(MSQuery *)query queryId:(NSString *)queryId completion:(MSSyncBlock)completion
+-(MSQueuePullOperation *)pullWithQuery:(MSQuery *)query queryId:(NSString *)queryId completion:(MSSyncBlock)completion
 {
-    [self.client.syncContext pullWithQuery:query queryId:queryId completion:completion];
+    return [self.client.syncContext pullWithQuery:query queryId:queryId completion:completion];
 }
 
--(void)purgeWithQuery:(MSQuery *)query completion:(MSSyncBlock)completion
+-(MSQueuePurgeOperation *)purgeWithQuery:(MSQuery *)query completion:(MSSyncBlock)completion
 {
     // If no query, purge all records in the table by default
     if (query == nil) {
         MSQuery *allRecords = [[MSQuery alloc] initWithSyncTable:self];
-        [self.client.syncContext purgeWithQuery:allRecords completion:completion];
+        return [self.client.syncContext purgeWithQuery:allRecords completion:completion];
         
     } else {
-        [self.client.syncContext purgeWithQuery:query completion:completion];
+        return [self.client.syncContext purgeWithQuery:query completion:completion];
     }
 }
 
 /// Purges all data, pending operations, operation errors, and metadata for the
 /// MSSyncTable from the local store.
--(void)forcePurgeWithCompletion:(MSSyncBlock)completion
+-(MSQueuePurgeOperation *)forcePurgeWithCompletion:(MSSyncBlock)completion
 {
-    [self.client.syncContext forcePurgeWithTable:self completion:completion];
+    return [self.client.syncContext forcePurgeWithTable:self completion:completion];
 }
 
 #pragma mark * Public Read Methods

--- a/sdk/iOS/test/MSSyncTableTests.m
+++ b/sdk/iOS/test/MSSyncTableTests.m
@@ -213,8 +213,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
         [expectation fulfill];
     }];
-	
-	XCTAssertNotNil(push);
+    
+    XCTAssertNotNil(push);
     
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
@@ -277,7 +277,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
         [expectation fulfill];
     }];
-	XCTAssertNotNil(push);
+    XCTAssertNotNil(push);
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
@@ -326,9 +326,9 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         [expectation fulfill];
         
     }];
-	
-	XCTAssertNotNil(push);
-	
+    
+    XCTAssertNotNil(push);
+    
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
@@ -358,13 +358,13 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     // Now push the first item to the server
     expectation = [self expectationWithDescription:@"Pushing First Insert"];
-		NSOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
+        NSOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(serverCalls == 1, @"the insert call didn't go to the server");
         
         [expectation fulfill];
     }];
-	XCTAssertNotNil(push);
+    XCTAssertNotNil(push);
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
     
     // Create the a new item and insert it
@@ -387,7 +387,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         
         [expectation fulfill];
     }];
-	XCTAssertNotNil(push);
+    XCTAssertNotNil(push);
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
@@ -447,7 +447,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         
         [expectation fulfill];
     }];
-	XCTAssertNotNil(push);
+    XCTAssertNotNil(push);
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
@@ -500,7 +500,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         [expectation fulfill];
         
     }];
-	XCTAssertNotNil(push);
+    XCTAssertNotNil(push);
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
@@ -544,7 +544,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         [expectation fulfill];
         
     }];
-	XCTAssertNotNil(push);
+    XCTAssertNotNil(push);
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
@@ -717,7 +717,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
         done = YES;
     }];
-	XCTAssertNotNil(push);
+    XCTAssertNotNil(push);
     XCTAssertTrue([self waitForTest:2000.1], @"Test timed out.");
 }
 
@@ -781,7 +781,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertTrue(callsToServer == 1, @"expected only 1 call to the server");
         done = YES;
     }];
-	XCTAssertNotNil(push);
+    XCTAssertNotNil(push);
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
 }
 
@@ -823,7 +823,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertTrue(callsToServer == 1, @"expected only 1 call to the server");
         done = YES;
     }];
-	XCTAssertNotNil(push);
+    XCTAssertNotNil(push);
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
 }
 
@@ -866,7 +866,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertTrue(deleteSentToServer, @"the delete call didn't go to the server");
         done = YES;
     }];
-	XCTAssertNotNil(push);
+    XCTAssertNotNil(push);
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
 }
 
@@ -905,7 +905,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertTrue(deleteSentToServer, @"the delete call didn't go to the server");
         done = YES;
     }];
-	XCTAssertNotNil(push);
+    XCTAssertNotNil(push);
     XCTAssertTrue([self waitForTest:2000.1], @"Test timed out.");
 }
 
@@ -992,8 +992,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertEqual(offline.upsertedItems, 2);
         done = YES;
     }];
-	
-	XCTAssertNotNil(pull);
+    
+    XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
@@ -1028,8 +1028,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertEqual((int)offline.upsertedItems, 2, @"Unexpected number of upsert calls");
         done = YES;
     }];
-	
-	XCTAssertNotNil(pull);
+    
+    XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
@@ -1064,9 +1064,9 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertEqual((int)offline.deletedItems, 1, @"Unexpected number of upsert calls");
         done = YES;
     }];
-	
-	XCTAssertNotNil(pull);
-	
+    
+    XCTAssertNotNil(pull);
+    
     XCTAssertTrue([self waitForTest:30.0], @"Test timed out.");
     
     NSURLRequest *firstRequest = testFilter.actualRequests[0];
@@ -1104,9 +1104,9 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         
         done = YES;
     }];
-	
-	XCTAssertNotNil(pull);
-	
+    
+    XCTAssertNotNil(pull);
+    
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
     NSURLRequest *insertRequest = testFilter.actualRequests[0];
@@ -1149,8 +1149,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         
         done = YES;
     }];
-	
-	XCTAssertNotNil(pull);
+    
+    XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:30.0], @"Test timed out.");
 }
@@ -1181,8 +1181,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         
         done = YES;
     }];
-	
-	XCTAssertNotNil(pull);
+    
+    XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:30.0], @"Test timed out.");
 }
@@ -1205,8 +1205,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertEqual((int)offline.upsertedItems, 2, @"Unexpected number of upsert calls");
         done = YES;
     }];
-	
-	XCTAssertNotNil(pull);
+    
+    XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:30.0], @"Test timed out.");
     
@@ -1247,8 +1247,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertEqual((int)offline.upsertedItems, 0, @"Unexpected number of upsert calls");
         done = YES;
     }];
-	
-	XCTAssertNil(pull);
+    
+    XCTAssertNil(pull);
     
     XCTAssertTrue([self waitForTest:30.0], @"Test timed out.");
 }
@@ -1267,13 +1267,13 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoTable];
     
     query.fetchLimit = 150;
-	
+    
     NSOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         done = YES;
     }];
-	
-	XCTAssertNotNil(pull);
+    
+    XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
@@ -1316,8 +1316,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertNil(error, @"Error found: %@", error.description);
         done = YES;
     }];
-	
-	XCTAssertNotNil(pull);
+    
+    XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
@@ -1366,8 +1366,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertNil(error, @"Error found: %@", error.description);
         done = YES;
     }];
-	
-	XCTAssertNotNil(pull);
+    
+    XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
@@ -1401,8 +1401,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertNil(error, @"Error found: %@", error.description);
         done = YES;
     }];
-	
-	XCTAssertNotNil(pull);
+    
+    XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
@@ -1451,8 +1451,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertNil(error, @"Error found: %@", error.description);
         done = YES;
     }];
-	
-	XCTAssertNotNil(pull);
+    
+    XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
@@ -1497,8 +1497,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertNil(error, @"Error found: %@", error.description);
         done = YES;
     }];
-	
-	XCTAssertNotNil(pull);
+    
+    XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
@@ -1544,8 +1544,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertNil(error, @"Error found: %@", error.description);
         done = YES;
     }];
-	
-	XCTAssertNotNil(pull);
+    
+    XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
@@ -1578,7 +1578,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         actualRequest = request;
         return request;
     };
-	
+    
     MSClient *filteredClient = [client clientWithFilter:testFilter];
     MSSyncTable *todoTable = [filteredClient syncTableWithName:@"TodoNoVersion"];
     
@@ -1607,7 +1607,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         
         done = YES;
     }];
-	XCTAssertNotNil(push);
+    XCTAssertNotNil(push);
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
 }
 
@@ -1636,8 +1636,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertEqual(offline.readTableCalls, 0);
         done = YES;
     }];
-	
-	XCTAssertNotNil(pull);
+    
+    XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:1000.1], @"Test timed out.");
     done = NO;
@@ -1694,8 +1694,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertEqual(offline.readTableCalls, 0);
         done = YES;
     }];
-	
-	XCTAssertNotNil(pull);
+    
+    XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:10000.1], @"Test timed out.");
     XCTAssertEqual(4, filter.actualRequests.count);
@@ -1732,8 +1732,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertEqual(offline.readTableCalls, 0);
         done = YES;
     }];
-	
-	XCTAssertNotNil(pull);
+    
+    XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     done = NO;
@@ -1762,8 +1762,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertEqual(offline.readTableCalls, 0);
         done = YES;
     }];
-	
-	XCTAssertNil(pull);
+    
+    XCTAssertNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     XCTAssertEqual(1, filter.actualRequests.count);
@@ -1785,19 +1785,19 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     };
     
     NSOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:completion];
-	XCTAssertNil(pull);
+    XCTAssertNil(pull);
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     done = NO;
     
     query.parameters = @{@"__includeDeleted":@YES, @"__INCLUDEDELETED":@NO};
     pull = [todoTable pullWithQuery:query queryId:nil completion:completion];
-	XCTAssertNil(pull);
+    XCTAssertNil(pull);
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     done = NO;
     
     query.parameters = @{@"__includeDeleted":@"NONSENSE"};
     pull = [todoTable pullWithQuery:query queryId:nil completion:completion];
-	XCTAssertNil(pull);
+    XCTAssertNil(pull);
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
 }
 
@@ -1836,8 +1836,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         NSLog(@"done pull");
         done = YES;
     }];
-	
-	XCTAssertNotNil(pull);
+    
+    XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:30.0], @"Test timed out.");
     
@@ -1928,8 +1928,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertEqual(offline.deletedItems, 1);
         done = YES;
     }];
-	
-	XCTAssertNotNil(pull);
+    
+    XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:30.0], @"Test timed out.");
     
@@ -1996,8 +1996,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertEqual(offline.upsertedItems, 11);
         done = YES;
     }];
-	
-	XCTAssertNotNil(pull);
+    
+    XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
@@ -2085,8 +2085,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertEqual(offline.upsertedItems, 4);
         done = YES;
     }];
-	
-	XCTAssertNotNil(pull);
+    
+    XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     XCTAssertEqual(3, filter.actualRequests.count);
@@ -2145,8 +2145,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         alreadyCalled = YES;
         done = YES;
     }];
-	
-	XCTAssertNotNil(pull);
+    
+    XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1]);
     done = NO;
@@ -2170,21 +2170,21 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     // verify error if fetchOffset is set
     query.fetchOffset = 10;
     NSOperation *pull = [todoTable pullWithQuery:query queryId:@"todo" completion:completion];
-	XCTAssertNil(pull);
+    XCTAssertNil(pull);
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     done = NO;
     
     // verify error if both fetchLimit and fetchOffset are set
     query.fetchLimit = 10;
     pull = [todoTable pullWithQuery:query queryId:@"todo" completion:completion];
-	XCTAssertNil(pull);
+    XCTAssertNil(pull);
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     done = NO;
     
     // now reset fetchOffset back to -1 and verify error if only fetchLimit is set
     query.fetchOffset = -1;
     pull = [todoTable pullWithQuery:query queryId:@"todo" completion:completion];
-	XCTAssertNil(pull);
+    XCTAssertNil(pull);
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
 }
 
@@ -2221,8 +2221,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         
         done = YES;
     }];
-	
-	XCTAssertNotNil(purge);
+    
+    XCTAssertNotNil(purge);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
 }
@@ -2258,9 +2258,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
             
             done = YES;
         }];
-		XCTAssertNotNil(purge);
+        XCTAssertNotNil(purge);
     }];
-    
     
     XCTAssertTrue([self waitForTest:30.0], @"Test timed out.");
 }
@@ -2380,7 +2379,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
             
             done = YES;
         }];
-		XCTAssertNotNil(purge);
+        XCTAssertNotNil(purge);
     }];
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");

--- a/sdk/iOS/test/MSSyncTableTests.m
+++ b/sdk/iOS/test/MSSyncTableTests.m
@@ -207,12 +207,14 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     // Now try sending the pending operation to the server
     expectation = [self expectationWithDescription:@"Push for Valid Item"];
     
-    [client.syncContext pushWithCompletion:^(NSError *error) {
+    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(insertRanToServer, @"the insert call didn't go to the server");
         XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
         [expectation fulfill];
     }];
+	
+	XCTAssertNotNil(push);
     
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
@@ -269,12 +271,13 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     // Now push this item to the server
     expectation = [self expectationWithDescription:@"Push with many column types"];
     
-    [client.syncContext pushWithCompletion:^(NSError *error) {
+    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(insertRanToServer, @"the insert call didn't go to the server");
         XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
         [expectation fulfill];
     }];
+	XCTAssertNotNil(push);
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
@@ -307,7 +310,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     // Now verify that the item is invalid for the server to handle
     expectation = [self expectationWithDescription:@"Push with Binary data in it"];
-    [client.syncContext pushWithCompletion:^(NSError *error) {
+    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertFalse(insertRanToServer);
         XCTAssertNotNil(error);
         XCTAssertEqual(error.code, MSPushCompleteWithErrors);
@@ -323,6 +326,9 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         [expectation fulfill];
         
     }];
+	
+	XCTAssertNotNil(push);
+	
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
@@ -352,12 +358,13 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     // Now push the first item to the server
     expectation = [self expectationWithDescription:@"Pushing First Insert"];
-    [client.syncContext pushWithCompletion:^(NSError *error) {
+    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(serverCalls == 1, @"the insert call didn't go to the server");
         
         [expectation fulfill];
     }];
+	XCTAssertNotNil(push);
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
     
     // Create the a new item and insert it
@@ -372,7 +379,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
 
     // Finally, push the second item to server
     expectation = [self expectationWithDescription:@"Pushing Second Insert"];
-    [client.syncContext pushWithCompletion:^(NSError *error) {
+    push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(serverCalls == 2, @"the insert call didn't go to the server");
         XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
@@ -380,6 +387,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         
         [expectation fulfill];
     }];
+	XCTAssertNotNil(push);
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
@@ -410,7 +418,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     // Now try to push and trigger a conflict response
     expectation = [self expectationWithDescription:@"Push with server conflict"];
-    [client.syncContext pushWithCompletion:^(NSError *error) {
+    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         // Verify the call went to the server
         XCTAssertEqual(serverCalls, 1, @"the insert call didn't go to the server");
         
@@ -439,6 +447,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         
         [expectation fulfill];
     }];
+	XCTAssertNotNil(push);
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
@@ -484,13 +493,14 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     // Push queue to server
     expectation = [self expectationWithDescription:self.name];
-    [client.syncContext pushWithCompletion:^(NSError *error) {
+    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(callsToServer == 1, @"only one call to server should have been made");
         XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
         [expectation fulfill];
         
     }];
+	XCTAssertNotNil(push);
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
@@ -527,13 +537,14 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     // Push to server (no calls expected)
     expectation = [self expectationWithDescription:@"Pushing (expecting no items)"];
-    [client.syncContext pushWithCompletion:^(NSError *error) {
+    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(callsToServer == 0, @"no calls to server should have been made");
         XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
         [expectation fulfill];
         
     }];
+	XCTAssertNotNil(push);
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
@@ -700,12 +711,13 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
     done = NO;
-    [client.syncContext pushWithCompletion:^(NSError *error) {
+    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(updateSentToServer, @"the update call didn't go to the server");
         XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
         done = YES;
     }];
+	XCTAssertNotNil(push);
     XCTAssertTrue([self waitForTest:2000.1], @"Test timed out.");
 }
 
@@ -764,11 +776,12 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
     done = NO;
-    [client.syncContext pushWithCompletion:^(NSError *error) {
+    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(callsToServer == 1, @"expected only 1 call to the server");
         done = YES;
     }];
+	XCTAssertNotNil(push);
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
 }
 
@@ -805,11 +818,12 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
     done = NO;
-    [client.syncContext pushWithCompletion:^(NSError *error) {
+    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(callsToServer == 1, @"expected only 1 call to the server");
         done = YES;
     }];
+	XCTAssertNotNil(push);
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
 }
 
@@ -847,11 +861,12 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
     done = NO;
-    [client.syncContext pushWithCompletion:^(NSError *error) {
+    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(deleteSentToServer, @"the delete call didn't go to the server");
         done = YES;
     }];
+	XCTAssertNotNil(push);
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
 }
 
@@ -885,11 +900,12 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     XCTAssertTrue([self waitForTest:1000.1], @"Test timed out.");
     
     done = NO;
-    [client.syncContext pushWithCompletion:^(NSError *error) {
+    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(deleteSentToServer, @"the delete call didn't go to the server");
         done = YES;
     }];
+	XCTAssertNotNil(push);
     XCTAssertTrue([self waitForTest:2000.1], @"Test timed out.");
 }
 
@@ -1580,7 +1596,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     done = NO;
     actualRequest = nil;
-    [client.syncContext pushWithCompletion:^(NSError *error) {
+    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertNotNil(actualRequest, @"actualRequest should not have been nil.");
         
@@ -1591,6 +1607,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         
         done = YES;
     }];
+	XCTAssertNotNil(push);
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
 }
 

--- a/sdk/iOS/test/MSSyncTableTests.m
+++ b/sdk/iOS/test/MSSyncTableTests.m
@@ -207,7 +207,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     // Now try sending the pending operation to the server
     expectation = [self expectationWithDescription:@"Push for Valid Item"];
     
-    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
+    NSOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(insertRanToServer, @"the insert call didn't go to the server");
         XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
@@ -271,7 +271,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     // Now push this item to the server
     expectation = [self expectationWithDescription:@"Push with many column types"];
     
-    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
+    NSOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(insertRanToServer, @"the insert call didn't go to the server");
         XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
@@ -310,7 +310,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     // Now verify that the item is invalid for the server to handle
     expectation = [self expectationWithDescription:@"Push with Binary data in it"];
-    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
+    NSOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertFalse(insertRanToServer);
         XCTAssertNotNil(error);
         XCTAssertEqual(error.code, MSPushCompleteWithErrors);
@@ -358,7 +358,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     // Now push the first item to the server
     expectation = [self expectationWithDescription:@"Pushing First Insert"];
-    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
+		NSOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(serverCalls == 1, @"the insert call didn't go to the server");
         
@@ -418,7 +418,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     // Now try to push and trigger a conflict response
     expectation = [self expectationWithDescription:@"Push with server conflict"];
-    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
+    NSOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         // Verify the call went to the server
         XCTAssertEqual(serverCalls, 1, @"the insert call didn't go to the server");
         
@@ -493,7 +493,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     // Push queue to server
     expectation = [self expectationWithDescription:self.name];
-    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
+    NSOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(callsToServer == 1, @"only one call to server should have been made");
         XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
@@ -537,7 +537,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     // Push to server (no calls expected)
     expectation = [self expectationWithDescription:@"Pushing (expecting no items)"];
-    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
+    NSOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(callsToServer == 0, @"no calls to server should have been made");
         XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
@@ -711,7 +711,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
     done = NO;
-    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
+    NSOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(updateSentToServer, @"the update call didn't go to the server");
         XCTAssertEqualObjects([NSOperationQueue currentQueue].name, SyncContextQueueName);
@@ -776,7 +776,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
     done = NO;
-    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
+    NSOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(callsToServer == 1, @"expected only 1 call to the server");
         done = YES;
@@ -818,7 +818,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
     done = NO;
-    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
+    NSOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(callsToServer == 1, @"expected only 1 call to the server");
         done = YES;
@@ -861,7 +861,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
     done = NO;
-    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
+    NSOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(deleteSentToServer, @"the delete call didn't go to the server");
         done = YES;
@@ -900,7 +900,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     XCTAssertTrue([self waitForTest:1000.1], @"Test timed out.");
     
     done = NO;
-    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
+    NSOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertTrue(deleteSentToServer, @"the delete call didn't go to the server");
         done = YES;
@@ -986,7 +986,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSSyncTable *todoTable = [filteredClient syncTableWithName:@"TodoItem"];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoTable];
     
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         XCTAssertEqual(offline.upsertCalls, 1);
         XCTAssertEqual(offline.upsertedItems, 2);
@@ -1022,7 +1022,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSSyncTable *todoTable = [filteredClient syncTableWithName:TodoTableNoVersion];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoTable];
     
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         XCTAssertEqual((int)offline.upsertCalls, 1, @"Unexpected number of upsert calls");
         XCTAssertEqual((int)offline.upsertedItems, 2, @"Unexpected number of upsert calls");
@@ -1056,7 +1056,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSSyncTable *todoTable = [filteredClient syncTableWithName:TodoTableNoVersion];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoTable];
     
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error occurred: %@", error.description);
         XCTAssertEqual((int)offline.upsertCalls, 1, @"Unexpected number of upsert calls");
         XCTAssertEqual((int)offline.upsertedItems, 2, @"Unexpected number of upsert calls");
@@ -1097,7 +1097,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     done = NO;
     
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Unexpected error: %@", error.description);
         XCTAssertEqual(offline.upsertCalls, 4);
         XCTAssertEqual(offline.upsertedItems, 5);
@@ -1138,7 +1138,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSSyncTable *todoTable = [filteredClient syncTableWithName:@"TodoItem"];
     MSQuery *query = [todoTable query];
     
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Unexpected error: %@", error.description);
         XCTAssertNotNil(actualRequest);
         
@@ -1170,7 +1170,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSSyncTable *todoTable = [filteredClient syncTableWithName:@"TodoItem"];
     MSQuery *query = [todoTable query];
     
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:@"something" completion:^(NSError *error) {
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:@"something" completion:^(NSError *error) {
         XCTAssertNil(error, @"Unexpected error: %@", error.description);
         XCTAssertNotNil(actualRequest);
         
@@ -1199,7 +1199,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoTable];
     query.parameters = @{@"mykey": @"myvalue"};
     
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         XCTAssertEqual((int)offline.upsertCalls, 1, @"Unexpected number of upsert calls");
         XCTAssertEqual((int)offline.upsertedItems, 2, @"Unexpected number of upsert calls");
@@ -1240,7 +1240,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoTable];
     query.parameters = @{@"__systemProperties": @"__createdAt%2C__somethingRandom"};
     
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNotNil(error);
         XCTAssertEqual(error.code, MSInvalidParameter);
         XCTAssertEqual((int)offline.upsertCalls, 0, @"Unexpected number of upsert calls");
@@ -1268,7 +1268,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     query.fetchLimit = 150;
 	
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         done = YES;
     }];
@@ -1312,7 +1312,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     query.fetchLimit = 1000;
     
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         done = YES;
     }];
@@ -1362,7 +1362,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     // we'd expect 4 calls ($top=25)
     query.fetchLimit = 25;
     
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         done = YES;
     }];
@@ -1397,7 +1397,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     // we'd expect 4 calls ($top=50, 50, 50, 50) ($skip=0, 25, 50, 60)
     query.fetchLimit = 100;
     
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         done = YES;
     }];
@@ -1447,7 +1447,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     // we'd expect 4 calls ($top=50, 50, 50, 50) ($skip=0, 25, 50, 60)
     query.fetchLimit = 148;
     
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         done = YES;
     }];
@@ -1493,7 +1493,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     // we'd expect 3 calls ($top=50, 50, 50) ($skip=12, 62, 100)
     query.fetchOffset = 12;
     
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         done = YES;
     }];
@@ -1540,7 +1540,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     query.fetchOffset = 12;
     query.fetchLimit = 110;
     
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         done = YES;
     }];
@@ -1596,7 +1596,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     done = NO;
     actualRequest = nil;
-    MSQueuePushOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
+    NSOperation *push = [client.syncContext pushWithCompletion:^(NSError *error) {
         XCTAssertNil(error, @"error should have been nil.");
         XCTAssertNotNil(actualRequest, @"actualRequest should not have been nil.");
         
@@ -1624,7 +1624,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     // Verifies that we allow __includeDeleted=YES
     // query.parameters = @{@"__includeDeleted":@YES};
     
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:@"test_1" completion:^(NSError *error) {
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:@"test_1" completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         XCTAssertEqual(offline.upsertCalls, 4);
         XCTAssertEqual(offline.upsertedItems, 6);
@@ -1725,7 +1725,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     query.orderBy = @[orderByText];
     
     // without queryId, it should work
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         XCTAssertEqual(offline.upsertCalls, 0);
         XCTAssertEqual(offline.upsertedItems, 0);
@@ -1784,7 +1784,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         done = YES;
     };
     
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:completion];
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:completion];
 	XCTAssertNil(pull);
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     done = NO;
@@ -1829,7 +1829,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         return request;
     };
     
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:@"test-1" completion:^(NSError *error) {
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:@"test-1" completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         XCTAssertEqual(offline.upsertCalls, 6);
         XCTAssertEqual(offline.upsertedItems, 8);
@@ -1919,7 +1919,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         return request;
     };
     
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:@"test-1" completion:^(NSError *error) {
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:@"test-1" completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         XCTAssertEqual(offline.upsertCalls, 9);
         XCTAssertEqual(offline.upsertedItems, 10);
@@ -1990,7 +1990,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSSyncTable *todoTable = [filteredClient syncTableWithName:@"TodoItem"];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoTable];
     
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:@"test_1" completion:^(NSError *error) {
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:@"test_1" completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         XCTAssertEqual(offline.upsertCalls, 7);
         XCTAssertEqual(offline.upsertedItems, 11);
@@ -2079,7 +2079,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoTable];
     query.predicate = [NSPredicate predicateWithFormat:@"text == 'MATCH'"];
     
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:@"test_1" completion:^(NSError *error) {
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:@"test_1" completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         XCTAssertEqual(offline.upsertCalls, 3);
         XCTAssertEqual(offline.upsertedItems, 4);
@@ -2139,7 +2139,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     // before the bug was fixed, an error would call the completion but continue to call the pull.
     // this fails with the bug but passes now that it's been fixed.
     __block BOOL alreadyCalled = NO;
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:@"something" completion:^(NSError *error) {
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:@"something" completion:^(NSError *error) {
         XCTAssertNotNil(error);
         XCTAssertFalse(alreadyCalled);
         alreadyCalled = YES;
@@ -2169,7 +2169,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     // verify error if fetchOffset is set
     query.fetchOffset = 10;
-    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:@"todo" completion:completion];
+    NSOperation *pull = [todoTable pullWithQuery:query queryId:@"todo" completion:completion];
 	XCTAssertNil(pull);
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     done = NO;
@@ -2204,7 +2204,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
                  orError:&storageError];
     XCTAssertNil(storageError);
     
-    MSQueuePurgeOperation *purge = [todoTable purgeWithQuery:query completion:^(NSError *error) {
+    NSOperation *purge = [todoTable purgeWithQuery:query completion:^(NSError *error) {
         XCTAssertNil(error, @"Unexpected error: %@", error.description);
         
         XCTAssertEqual(offline.deleteCalls, 1);
@@ -2244,7 +2244,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSSyncTable *todoTable = [filteredClient syncTableWithName:TodoTableNoVersion];
     
     [testTable insert:@{ @"name": @"test one"} completion:^(NSDictionary *item, NSError *error) {
-        MSQueuePurgeOperation *purge = [todoTable purgeWithQuery:nil completion:^(NSError *error) {
+        NSOperation *purge = [todoTable purgeWithQuery:nil completion:^(NSError *error) {
             XCTAssertNil(error, @"Unexpected error: %@", error.description);
             
             XCTAssertEqual(offline.deleteCalls, 1);
@@ -2372,7 +2372,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoTable];
     
     [todoTable insert:@{ @"name": @"test one"} completion:^(NSDictionary *item, NSError *error) {
-        MSQueuePurgeOperation *purge = [todoTable purgeWithQuery:query completion:^(NSError *error) {
+        NSOperation *purge = [todoTable purgeWithQuery:query completion:^(NSError *error) {
             XCTAssertNotNil(error);
             XCTAssertEqual(error.code, MSPurgeAbortedPendingChanges);
             XCTAssertEqual(offline.deleteCalls, 0);

--- a/sdk/iOS/test/MSSyncTableTests.m
+++ b/sdk/iOS/test/MSSyncTableTests.m
@@ -1578,7 +1578,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         actualRequest = request;
         return request;
     };
-    
+	
     MSClient *filteredClient = [client clientWithFilter:testFilter];
     MSSyncTable *todoTable = [filteredClient syncTableWithName:@"TodoNoVersion"];
     
@@ -2204,7 +2204,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
                  orError:&storageError];
     XCTAssertNil(storageError);
     
-    [todoTable purgeWithQuery:query completion:^(NSError *error) {
+    MSQueuePurgeOperation *purge = [todoTable purgeWithQuery:query completion:^(NSError *error) {
         XCTAssertNil(error, @"Unexpected error: %@", error.description);
         
         XCTAssertEqual(offline.deleteCalls, 1);
@@ -2221,6 +2221,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         
         done = YES;
     }];
+	
+	XCTAssertNotNil(purge);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
 }
@@ -2242,7 +2244,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSSyncTable *todoTable = [filteredClient syncTableWithName:TodoTableNoVersion];
     
     [testTable insert:@{ @"name": @"test one"} completion:^(NSDictionary *item, NSError *error) {
-        [todoTable purgeWithQuery:nil completion:^(NSError *error) {
+        MSQueuePurgeOperation *purge = [todoTable purgeWithQuery:nil completion:^(NSError *error) {
             XCTAssertNil(error, @"Unexpected error: %@", error.description);
             
             XCTAssertEqual(offline.deleteCalls, 1);
@@ -2256,6 +2258,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
             
             done = YES;
         }];
+		XCTAssertNotNil(purge);
     }];
     
     
@@ -2369,7 +2372,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoTable];
     
     [todoTable insert:@{ @"name": @"test one"} completion:^(NSDictionary *item, NSError *error) {
-        [todoTable purgeWithQuery:query completion:^(NSError *error) {
+        MSQueuePurgeOperation *purge = [todoTable purgeWithQuery:query completion:^(NSError *error) {
             XCTAssertNotNil(error);
             XCTAssertEqual(error.code, MSPurgeAbortedPendingChanges);
             XCTAssertEqual(offline.deleteCalls, 0);
@@ -2377,6 +2380,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
             
             done = YES;
         }];
+		XCTAssertNotNil(purge);
     }];
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");

--- a/sdk/iOS/test/MSSyncTableTests.m
+++ b/sdk/iOS/test/MSSyncTableTests.m
@@ -970,12 +970,14 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSSyncTable *todoTable = [filteredClient syncTableWithName:@"TodoItem"];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoTable];
     
-    [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         XCTAssertEqual(offline.upsertCalls, 1);
         XCTAssertEqual(offline.upsertedItems, 2);
         done = YES;
     }];
+	
+	XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
@@ -1004,12 +1006,14 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSSyncTable *todoTable = [filteredClient syncTableWithName:TodoTableNoVersion];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoTable];
     
-    [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         XCTAssertEqual((int)offline.upsertCalls, 1, @"Unexpected number of upsert calls");
         XCTAssertEqual((int)offline.upsertedItems, 2, @"Unexpected number of upsert calls");
         done = YES;
     }];
+	
+	XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
@@ -1036,7 +1040,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSSyncTable *todoTable = [filteredClient syncTableWithName:TodoTableNoVersion];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoTable];
     
-    [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error occurred: %@", error.description);
         XCTAssertEqual((int)offline.upsertCalls, 1, @"Unexpected number of upsert calls");
         XCTAssertEqual((int)offline.upsertedItems, 2, @"Unexpected number of upsert calls");
@@ -1044,7 +1048,9 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertEqual((int)offline.deletedItems, 1, @"Unexpected number of upsert calls");
         done = YES;
     }];
-    
+	
+	XCTAssertNotNil(pull);
+	
     XCTAssertTrue([self waitForTest:30.0], @"Test timed out.");
     
     NSURLRequest *firstRequest = testFilter.actualRequests[0];
@@ -1075,13 +1081,16 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     done = NO;
     
-    [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Unexpected error: %@", error.description);
         XCTAssertEqual(offline.upsertCalls, 4);
         XCTAssertEqual(offline.upsertedItems, 5);
         
         done = YES;
     }];
+	
+	XCTAssertNotNil(pull);
+	
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
     NSURLRequest *insertRequest = testFilter.actualRequests[0];
@@ -1113,7 +1122,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSSyncTable *todoTable = [filteredClient syncTableWithName:@"TodoItem"];
     MSQuery *query = [todoTable query];
     
-    [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Unexpected error: %@", error.description);
         XCTAssertNotNil(actualRequest);
         
@@ -1124,6 +1133,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         
         done = YES;
     }];
+	
+	XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:30.0], @"Test timed out.");
 }
@@ -1143,7 +1154,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSSyncTable *todoTable = [filteredClient syncTableWithName:@"TodoItem"];
     MSQuery *query = [todoTable query];
     
-    [todoTable pullWithQuery:query queryId:@"something" completion:^(NSError *error) {
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:@"something" completion:^(NSError *error) {
         XCTAssertNil(error, @"Unexpected error: %@", error.description);
         XCTAssertNotNil(actualRequest);
         
@@ -1154,6 +1165,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         
         done = YES;
     }];
+	
+	XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:30.0], @"Test timed out.");
 }
@@ -1170,12 +1183,14 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoTable];
     query.parameters = @{@"mykey": @"myvalue"};
     
-    [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         XCTAssertEqual((int)offline.upsertCalls, 1, @"Unexpected number of upsert calls");
         XCTAssertEqual((int)offline.upsertedItems, 2, @"Unexpected number of upsert calls");
         done = YES;
     }];
+	
+	XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:30.0], @"Test timed out.");
     
@@ -1209,13 +1224,15 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoTable];
     query.parameters = @{@"__systemProperties": @"__createdAt%2C__somethingRandom"};
     
-    [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNotNil(error);
         XCTAssertEqual(error.code, MSInvalidParameter);
         XCTAssertEqual((int)offline.upsertCalls, 0, @"Unexpected number of upsert calls");
         XCTAssertEqual((int)offline.upsertedItems, 0, @"Unexpected number of upsert calls");
         done = YES;
     }];
+	
+	XCTAssertNil(pull);
     
     XCTAssertTrue([self waitForTest:30.0], @"Test timed out.");
 }
@@ -1234,11 +1251,13 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoTable];
     
     query.fetchLimit = 150;
-    
-    [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+	
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         done = YES;
     }];
+	
+	XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
@@ -1277,10 +1296,12 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     query.fetchLimit = 1000;
     
-    [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         done = YES;
     }];
+	
+	XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
@@ -1325,10 +1346,12 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     // we'd expect 4 calls ($top=25)
     query.fetchLimit = 25;
     
-    [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         done = YES;
     }];
+	
+	XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
@@ -1358,10 +1381,12 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     // we'd expect 4 calls ($top=50, 50, 50, 50) ($skip=0, 25, 50, 60)
     query.fetchLimit = 100;
     
-    [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         done = YES;
     }];
+	
+	XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
@@ -1406,10 +1431,12 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     // we'd expect 4 calls ($top=50, 50, 50, 50) ($skip=0, 25, 50, 60)
     query.fetchLimit = 148;
     
-    [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         done = YES;
     }];
+	
+	XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
@@ -1450,10 +1477,12 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     // we'd expect 3 calls ($top=50, 50, 50) ($skip=12, 62, 100)
     query.fetchOffset = 12;
     
-    [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         done = YES;
     }];
+	
+	XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
@@ -1495,10 +1524,12 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     query.fetchOffset = 12;
     query.fetchLimit = 110;
     
-    [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         done = YES;
     }];
+	
+	XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
@@ -1576,7 +1607,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     // Verifies that we allow __includeDeleted=YES
     // query.parameters = @{@"__includeDeleted":@YES};
     
-    [todoTable pullWithQuery:query queryId:@"test_1" completion:^(NSError *error) {
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:@"test_1" completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         XCTAssertEqual(offline.upsertCalls, 4);
         XCTAssertEqual(offline.upsertedItems, 6);
@@ -1588,6 +1619,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertEqual(offline.readTableCalls, 0);
         done = YES;
     }];
+	
+	XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:1000.1], @"Test timed out.");
     done = NO;
@@ -1634,7 +1667,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     // now try again and make sure we start with the same deltaToken
     [offline resetCounts];
-    [todoTable pullWithQuery:query queryId:@"test_1" completion:^(NSError *error) {
+    pull = [todoTable pullWithQuery:query queryId:@"test_1" completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         XCTAssertEqual(offline.upsertCalls, 0);
         XCTAssertEqual(offline.upsertedItems, 0);
@@ -1644,6 +1677,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertEqual(offline.readTableCalls, 0);
         done = YES;
     }];
+	
+	XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:10000.1], @"Test timed out.");
     XCTAssertEqual(4, filter.actualRequests.count);
@@ -1673,13 +1708,15 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     query.orderBy = @[orderByText];
     
     // without queryId, it should work
-    [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         XCTAssertEqual(offline.upsertCalls, 0);
         XCTAssertEqual(offline.upsertedItems, 0);
         XCTAssertEqual(offline.readTableCalls, 0);
         done = YES;
     }];
+	
+	XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     done = NO;
@@ -1699,7 +1736,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     [offline resetCounts];
     // with queryId, this should produce an error
-    [todoTable pullWithQuery:query queryId:@"test_1" completion:^(NSError *error) {
+    pull = [todoTable pullWithQuery:query queryId:@"test_1" completion:^(NSError *error) {
         XCTAssertNotNil(error);
         XCTAssertEqual(MSInvalidParameter, error.code);
         XCTAssertEqual(offline.upsertCalls, 0);
@@ -1708,6 +1745,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertEqual(offline.readTableCalls, 0);
         done = YES;
     }];
+	
+	XCTAssertNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     XCTAssertEqual(1, filter.actualRequests.count);
@@ -1728,17 +1767,20 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         done = YES;
     };
     
-    [todoTable pullWithQuery:query queryId:nil completion:completion];
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:nil completion:completion];
+	XCTAssertNil(pull);
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     done = NO;
     
     query.parameters = @{@"__includeDeleted":@YES, @"__INCLUDEDELETED":@NO};
-    [todoTable pullWithQuery:query queryId:nil completion:completion];
+    pull = [todoTable pullWithQuery:query queryId:nil completion:completion];
+	XCTAssertNil(pull);
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     done = NO;
     
     query.parameters = @{@"__includeDeleted":@"NONSENSE"};
-    [todoTable pullWithQuery:query queryId:nil completion:completion];
+    pull = [todoTable pullWithQuery:query queryId:nil completion:completion];
+	XCTAssertNil(pull);
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
 }
 
@@ -1770,13 +1812,15 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         return request;
     };
     
-    [todoTable pullWithQuery:query queryId:@"test-1" completion:^(NSError *error) {
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:@"test-1" completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         XCTAssertEqual(offline.upsertCalls, 6);
         XCTAssertEqual(offline.upsertedItems, 8);
         NSLog(@"done pull");
         done = YES;
     }];
+	
+	XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:30.0], @"Test timed out.");
     
@@ -1858,7 +1902,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         return request;
     };
     
-    [todoTable pullWithQuery:query queryId:@"test-1" completion:^(NSError *error) {
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:@"test-1" completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         XCTAssertEqual(offline.upsertCalls, 9);
         XCTAssertEqual(offline.upsertedItems, 10);
@@ -1867,6 +1911,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         XCTAssertEqual(offline.deletedItems, 1);
         done = YES;
     }];
+	
+	XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:30.0], @"Test timed out.");
     
@@ -1927,12 +1973,14 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSSyncTable *todoTable = [filteredClient syncTableWithName:@"TodoItem"];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoTable];
     
-    [todoTable pullWithQuery:query queryId:@"test_1" completion:^(NSError *error) {
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:@"test_1" completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         XCTAssertEqual(offline.upsertCalls, 7);
         XCTAssertEqual(offline.upsertedItems, 11);
         done = YES;
     }];
+	
+	XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     
@@ -2014,12 +2062,14 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoTable];
     query.predicate = [NSPredicate predicateWithFormat:@"text == 'MATCH'"];
     
-    [todoTable pullWithQuery:query queryId:@"test_1" completion:^(NSError *error) {
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:@"test_1" completion:^(NSError *error) {
         XCTAssertNil(error, @"Error found: %@", error.description);
         XCTAssertEqual(offline.upsertCalls, 3);
         XCTAssertEqual(offline.upsertedItems, 4);
         done = YES;
     }];
+	
+	XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     XCTAssertEqual(3, filter.actualRequests.count);
@@ -2072,12 +2122,14 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     // before the bug was fixed, an error would call the completion but continue to call the pull.
     // this fails with the bug but passes now that it's been fixed.
     __block BOOL alreadyCalled = NO;
-    [todoTable pullWithQuery:query queryId:@"something" completion:^(NSError *error) {
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:@"something" completion:^(NSError *error) {
         XCTAssertNotNil(error);
         XCTAssertFalse(alreadyCalled);
         alreadyCalled = YES;
         done = YES;
     }];
+	
+	XCTAssertNotNil(pull);
     
     XCTAssertTrue([self waitForTest:0.1]);
     done = NO;
@@ -2100,19 +2152,22 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     // verify error if fetchOffset is set
     query.fetchOffset = 10;
-    [todoTable pullWithQuery:query queryId:@"todo" completion:completion];
+    MSQueuePullOperation *pull = [todoTable pullWithQuery:query queryId:@"todo" completion:completion];
+	XCTAssertNil(pull);
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     done = NO;
     
     // verify error if both fetchLimit and fetchOffset are set
     query.fetchLimit = 10;
-    [todoTable pullWithQuery:query queryId:@"todo" completion:completion];
+    pull = [todoTable pullWithQuery:query queryId:@"todo" completion:completion];
+	XCTAssertNil(pull);
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
     done = NO;
     
     // now reset fetchOffset back to -1 and verify error if only fetchLimit is set
     query.fetchOffset = -1;
-    [todoTable pullWithQuery:query queryId:@"todo" completion:completion];
+    pull = [todoTable pullWithQuery:query queryId:@"todo" completion:completion];
+	XCTAssertNil(pull);
     XCTAssertTrue([self waitForTest:0.1], @"Test timed out.");
 }
 


### PR DESCRIPTION
Closes #703 by bringing these changes into dev branch first.

Returns NSOperation types from sync operations to allow the use to use them to react to changes. This could be to cancel, or to add these as dependencies to a trailing operation.