### PR TITLE
[iOS] [offline] Fix potential race conditions while adding items to sync table

### DIFF
--- a/sdk/iOS/src/MSSyncContext.m
+++ b/sdk/iOS/src/MSSyncContext.m
@@ -53,7 +53,7 @@ static NSOperationQueue *pushQueue_;
     self = [super init];
     if (self)
     {
-        writeOperationQueue = dispatch_queue_create("WriteOperationQueue", DISPATCH_QUEUE_CONCURRENT);
+        writeOperationQueue = dispatch_queue_create("WriteOperationQueue", DISPATCH_QUEUE_SERIAL);
         
         callbackQueue_ = callbackQueue;
         if (!callbackQueue_) {


### PR DESCRIPTION
- The write operation dispatch queue is defined as concurrent, however,
the tasks that run in it are not thread safe.
- Changing dispatch queue type from concurrent to serial will take care
of it
- In the future, if needed, we can change it back to concurrent and
make the tasks that run in it thread safe.