### PR TITLE
Push/Pull cancellability UTs

### DIFF
--- a/sdk/iOS/test/MSSyncTableTests.m
+++ b/sdk/iOS/test/MSSyncTableTests.m
@@ -1089,15 +1089,15 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
 // - Verifies that the expected number of items are pushed to the server
 -(void) testPushCancellability
 {
-    XCTAssertEqual([self performPushWithCancellationPoint:0 serverResponseCode:@200], 0, "Push cancellation failed");
-    XCTAssertEqual([self performPushWithCancellationPoint:1 serverResponseCode:@200], 0, "Push cancellation failed");
-    XCTAssertEqual([self performPushWithCancellationPoint:2 serverResponseCode:@200], 1, "Push cancellation failed");
-    XCTAssertEqual([self performPushWithCancellationPoint:3 serverResponseCode:@200], 0, "Push cancellation failed");
+    XCTAssertEqual([self performPushWithCancellationPoint:0 serverResponseCode:200], 0, "Push cancellation failed");
+    XCTAssertEqual([self performPushWithCancellationPoint:1 serverResponseCode:200], 0, "Push cancellation failed");
+    XCTAssertEqual([self performPushWithCancellationPoint:2 serverResponseCode:200], 1, "Push cancellation failed");
+    XCTAssertEqual([self performPushWithCancellationPoint:3 serverResponseCode:200], 0, "Push cancellation failed");
 
-    XCTAssertEqual([self performPushWithCancellationPoint:0 serverResponseCode:@500], 0, "Push cancellation failed");
-    XCTAssertEqual([self performPushWithCancellationPoint:1 serverResponseCode:@500], 0, "Push cancellation failed");
-    XCTAssertEqual([self performPushWithCancellationPoint:2 serverResponseCode:@500], 0, "Push cancellation failed");
-    XCTAssertEqual([self performPushWithCancellationPoint:3 serverResponseCode:@500], 0, "Push cancellation failed");
+    XCTAssertEqual([self performPushWithCancellationPoint:0 serverResponseCode:500], 0, "Push cancellation failed");
+    XCTAssertEqual([self performPushWithCancellationPoint:1 serverResponseCode:500], 0, "Push cancellation failed");
+    XCTAssertEqual([self performPushWithCancellationPoint:2 serverResponseCode:500], 0, "Push cancellation failed");
+    XCTAssertEqual([self performPushWithCancellationPoint:3 serverResponseCode:500], 0, "Push cancellation failed");
 }
 
 // Performs push and cancels it at the specified cancellation point.
@@ -1105,10 +1105,10 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
 // - Verifies that cancelling a push finishes the push NSOperation regardless of the cancellation point
 // - Verifies that the expected number of items are pushed to the server
 // - Returns the number of items pushed to the server.
--(int) performPushWithCancellationPoint:(int) requestedCancellationPoint serverResponseCode:(NSNumber *)serverResponseCode
+-(int) performPushWithCancellationPoint:(int) requestedCancellationPoint serverResponseCode:(NSInteger)serverResponseCode
 {
     // Initialization
-    MSMultiRequestTestFilter *filter = [MSMultiRequestTestFilter testFilterWithStatusCodes:@[serverResponseCode] data:@[@"{\"id\": \"id1\", \"text\":\"server\"}"] appendEmptyRequest:YES];
+    MSTestFilter *filter = [MSTestFilter testFilterWithStatusCode:serverResponseCode data:@"{\"id\": \"id1\", \"text\":\"server\"}"];
     MSClient *filteredClient = [client clientWithFilter:filter];
     MSSyncTable *todoTable = [filteredClient syncTableWithName:TodoTableNoVersion];
 
@@ -1119,8 +1119,8 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
 
     __block NSOperation *pushOperation;
 
-    // Define filters
-    ((MSTestFilter *)filter.testFilters[0]).onInspectRequest = ^(NSURLRequest *request) {
+    // Define the filter
+    filter.onInspectRequest = ^(NSURLRequest *request) {
 
         // Cancellation point 0
         if (requestedCancellationPoint == 0) {
@@ -1130,7 +1130,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
         return request;
     };
     
-    ((MSTestFilter *)filter.testFilters[0]).onInspectResponseData = ^(NSURLRequest *request, NSData *data) {
+    filter.onInspectResponseData = ^(NSURLRequest *request, NSData *data) {
 
         // Cancellation point 1
         if (requestedCancellationPoint == 1) {

--- a/sdk/iOS/test/MSSyncTableTests.m
+++ b/sdk/iOS/test/MSSyncTableTests.m
@@ -1087,11 +1087,35 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
 // - Verifies that a push following a cancelled push operation works as expected
 // - Verifies that cancelling a push operation finishes the push NSOperation regardless of the cancellation point
 // - Verifies that the expected number of items are pushed to the server
--(void) testPushCancellability_successfulpush
+-(void) testPushCancellability_SuccessfulPush_CancelBeforeSendingPushRequest
 {
     XCTAssertEqual([self performPushWithCancellationPoint:0 serverResponseCode:200], 0, "Push cancellation failed at cancellation point 0");
+}
+
+// Tests cancellation of the push operation at various stages of a push workflow.
+// - Verifies that a push following a cancelled push operation works as expected
+// - Verifies that cancelling a push operation finishes the push NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pushed to the server
+-(void) testPushCancellability_SuccessfulPush_CancelWhileProcessingPushreponse
+{
     XCTAssertEqual([self performPushWithCancellationPoint:1 serverResponseCode:200], 0, "Push cancellation failed at cancellation point 1");
+}
+
+// Tests cancellation of the push operation at various stages of a push workflow.
+// - Verifies that a push following a cancelled push operation works as expected
+// - Verifies that cancelling a push operation finishes the push NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pushed to the server
+-(void) testPushCancellability_SuccessfulPush_CancelFromCompletionBlock
+{
     XCTAssertEqual([self performPushWithCancellationPoint:2 serverResponseCode:200], 1, "Push cancellation failed at cancellation point 2");
+}
+
+// Tests cancellation of the push operation at various stages of a push workflow.
+// - Verifies that a push following a cancelled push operation works as expected
+// - Verifies that cancelling a push operation finishes the push NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pushed to the server
+-(void) testPushCancellability_SuccessfulPush_CancelRightAfterPushWithCompletionReturns
+{
     XCTAssertEqual([self performPushWithCancellationPoint:3 serverResponseCode:200], 0, "Push cancellation failed at cancellation point 3");
 }
 
@@ -1099,11 +1123,36 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
 // - Verifies that a push following a cancelled push operation works as expected
 // - Verifies that cancelling a push operation finishes the push NSOperation regardless of the cancellation point
 // - Verifies that the expected number of items are pushed to the server
--(void) testPushCancellability_unsuccessfulpush
+-(void) testPushCancellability_UnsuccessfulPush_CancelBeforeSendingPushRequest
 {
     XCTAssertEqual([self performPushWithCancellationPoint:0 serverResponseCode:500], 0, "Push cancellation failed at cancellation point 0");
+}
+
+
+// Tests cancellation of the push operation at various stages of a push workflow.
+// - Verifies that a push following a cancelled push operation works as expected
+// - Verifies that cancelling a push operation finishes the push NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pushed to the server
+-(void) testPushCancellability_UnsuccessfulPush_CancelWhileProcessingPushreponse
+{
     XCTAssertEqual([self performPushWithCancellationPoint:1 serverResponseCode:500], 0, "Push cancellation failed at cancellation point 1");
+}
+
+// Tests cancellation of the push operation at various stages of a push workflow.
+// - Verifies that a push following a cancelled push operation works as expected
+// - Verifies that cancelling a push operation finishes the push NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pushed to the server
+-(void) testPushCancellability_UnsuccessfulPush_CancelFromCompletionBlock
+{
     XCTAssertEqual([self performPushWithCancellationPoint:2 serverResponseCode:500], 0, "Push cancellation failed at cancellation point 2");
+}
+
+// Tests cancellation of the push operation at various stages of a push workflow.
+// - Verifies that a push following a cancelled push operation works as expected
+// - Verifies that cancelling a push operation finishes the push NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pushed to the server
+-(void) testPushCancellability_UnsuccessfulPush_CancelRightAfterPushWithCompletionReturns
+{
     XCTAssertEqual([self performPushWithCancellationPoint:3 serverResponseCode:500], 0, "Push cancellation failed at cancellation point 3");
 }
 
@@ -1112,17 +1161,16 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
 // - Verifies that cancelling a push finishes the push NSOperation regardless of the cancellation point
 // - Verifies that the expected number of items are pushed to the server
 // - Returns the number of items pushed to the server.
+// Cancellation point 0: just before the push request is sent to the server
+// Cancellation point 1: while processing the push response
+// Cancellation point 2: while executing the push completion block
+// Cancellation point 4: immediately after the push NSOperation is returned by pushWithCompletion:
 -(int) performPushWithCancellationPoint:(int) requestedCancellationPoint serverResponseCode:(NSInteger)serverResponseCode
 {
     // Initialization
     MSTestFilter *filter = [MSTestFilter testFilterWithStatusCode:serverResponseCode data:@"{\"id\": \"id1\", \"text\":\"server\"}"];
     MSClient *filteredClient = [client clientWithFilter:filter];
     MSSyncTable *todoTable = [filteredClient syncTableWithName:TodoTableNoVersion];
-
-    // Start with a clean slate
-    [[todoTable forcePurgeWithCompletion:^(NSError *error) {
-        XCTAssertNil(error, @"error should have been nil.");
-    }] waitUntilFinished];
 
     __block NSOperation *pushOperation;
 
@@ -1268,13 +1316,55 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
 // - Verifies that a pull operation following a cancelled pull operation works as expected
 // - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
 // - Verifies that the expected number of items are pulled from the server
--(void) testPullCancellability_successfulpush_successfulpull
+-(void) testPullCancellability_SuccessfulPush_SuccessfulPull_CancelBeforeSendingPushRequest
 {
     XCTAssertEqual([self performPullWithCancellationPoint:0 serverPushResponseCode:@200 serverPullResponseCode:@200], 1, "Pull cancellation failed at cancellation point 0");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_SuccessfulPush_SuccessfulPull_CancelWhileProcessingPushResponse
+
+{
     XCTAssertEqual([self performPullWithCancellationPoint:1 serverPushResponseCode:@200 serverPullResponseCode:@200], 1, "Pull cancellation failed at cancellation point 1");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_SuccessfulPush_SuccessfulPull_CancelBeforeSendingPullReuest
+{
     XCTAssertEqual([self performPullWithCancellationPoint:2 serverPushResponseCode:@200 serverPullResponseCode:@200], 1, "Pull cancellation failed at cancellation point 2");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_SuccessfulPush_SuccessfulPull_CancelWhileProcessingPullResponse
+{
     XCTAssertEqual([self performPullWithCancellationPoint:3 serverPushResponseCode:@200 serverPullResponseCode:@200], 1, "Pull cancellation failed at cancellation point 3");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_SuccessfulPush_SuccessfulPull_CancelFromCompletionBlock
+{
+
     XCTAssertEqual([self performPullWithCancellationPoint:4 serverPushResponseCode:@200 serverPullResponseCode:@200], 2, "Pull cancellation failed at cancellation point 4");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_SuccessfulPush_SuccessfulPull_CancelRightAfterPullWithQueryReturns
+{
     XCTAssertEqual([self performPullWithCancellationPoint:5 serverPushResponseCode:@200 serverPullResponseCode:@200], 1, "Pull cancellation failed at cancellation point 5");
 }
 
@@ -1282,13 +1372,54 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
 // - Verifies that a pull operation following a cancelled pull operation works as expected
 // - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
 // - Verifies that the expected number of items are pulled from the server
--(void) testPullCancellability_successfulpush_unsuccessfulpull
+-(void) testPullCancellability_SuccessfulPush_UnsuccessfulPull_CancelBeforeSendingPushRequest
 {
     XCTAssertEqual([self performPullWithCancellationPoint:0 serverPushResponseCode:@200 serverPullResponseCode:@500], 1, "Pull cancellation failed at cancellation point 0");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_SuccessfulPush_UnsuccessfulPull_CancelWhileProcessingPushResponse
+{
+
     XCTAssertEqual([self performPullWithCancellationPoint:1 serverPushResponseCode:@200 serverPullResponseCode:@500], 1, "Pull cancellation failed at cancellation point 1");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_SuccessfulPush_UnsuccessfulPull_CancelBeforeSendingPullReuest
+{
     XCTAssertEqual([self performPullWithCancellationPoint:2 serverPushResponseCode:@200 serverPullResponseCode:@500], 1, "Pull cancellation failed at cancellation point 2");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_SuccessfulPush_UnsuccessfulPull_CancelWhileProcessingPullResponse
+{
     XCTAssertEqual([self performPullWithCancellationPoint:3 serverPushResponseCode:@200 serverPullResponseCode:@500], 1, "Pull cancellation failed at cancellation point 3");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_SuccessfulPush_UnsuccessfulPull_CancelFromCompletionBlock
+{
     XCTAssertEqual([self performPullWithCancellationPoint:4 serverPushResponseCode:@200 serverPullResponseCode:@500], 1, "Pull cancellation failed at cancellation point 4");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_SuccessfulPush_UnsuccessfulPull_CancelRightAfterPullWithQueryReturns
+{
     XCTAssertEqual([self performPullWithCancellationPoint:5 serverPushResponseCode:@200 serverPullResponseCode:@500], 1, "Pull cancellation failed at cancellation point 5");
 }
 
@@ -1296,13 +1427,54 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
 // - Verifies that a pull operation following a cancelled pull operation works as expected
 // - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
 // - Verifies that the expected number of items are pulled from the server
--(void) testPullCancellability_unsuccessfulpush_successfulpull
+-(void) testPullCancellability_UnsuccessfulPush_SuccessfulPull_CancelBeforeSendingPushRequest
 {
     XCTAssertEqual([self performPullWithCancellationPoint:0 serverPushResponseCode:@500 serverPullResponseCode:@200], 0, "Pull cancellation failed at cancellation point 0");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_UnsuccessfulPush_SuccessfulPull_CancelWhileProcessingPushResponse
+
+{
     XCTAssertEqual([self performPullWithCancellationPoint:1 serverPushResponseCode:@500 serverPullResponseCode:@200], 0, "Pull cancellation failed at cancellation point 1");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_UnsuccessfulPush_SuccessfulPull_CancelBeforeSendingPullReuest
+{
     XCTAssertEqual([self performPullWithCancellationPoint:2 serverPushResponseCode:@500 serverPullResponseCode:@200], 0, "Pull cancellation failed at cancellation point 2");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_UnsuccessfulPush_SuccessfulPull_CancelWhileProcessingPullResponse
+{
     XCTAssertEqual([self performPullWithCancellationPoint:3 serverPushResponseCode:@500 serverPullResponseCode:@200], 0, "Pull cancellation failed at cancellation point 3");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_UnsuccessfulPush_SuccessfulPull_CancelFromCompletionBlock
+{
     XCTAssertEqual([self performPullWithCancellationPoint:4 serverPushResponseCode:@500 serverPullResponseCode:@200], 0, "Pull cancellation failed at cancellation point 4");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_UnsuccessfulPush_SuccessfulPull_CancelRightAfterPullWithQueryReturns
+{
     XCTAssertEqual([self performPullWithCancellationPoint:5 serverPushResponseCode:@500 serverPullResponseCode:@200], 0, "Pull cancellation failed at cancellation point 5");
 }
 
@@ -1310,13 +1482,53 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
 // - Verifies that a pull operation following a cancelled pull operation works as expected
 // - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
 // - Verifies that the expected number of items are pulled from the server
--(void) testPullCancellability_unsuccessfulpush_unsuccessfulpull
+-(void) testPullCancellability_UnsuccessfulPush_UnsuccessfulPull_CancelBeforeSendingPushRequest
 {
     XCTAssertEqual([self performPullWithCancellationPoint:0 serverPushResponseCode:@500 serverPullResponseCode:@500], 0, "Pull cancellation failed at cancellation point 0");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_UnsuccessfulPush_UnsuccessfulPull
+{
     XCTAssertEqual([self performPullWithCancellationPoint:1 serverPushResponseCode:@500 serverPullResponseCode:@500], 0, "Pull cancellation failed at cancellation point 1");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_UnsuccessfulPush_UnsuccessfulPull_CancelBeforeSendingPullReuest
+{
     XCTAssertEqual([self performPullWithCancellationPoint:2 serverPushResponseCode:@500 serverPullResponseCode:@500], 0, "Pull cancellation failed at cancellation point 2");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_UnsuccessfulPush_UnsuccessfulPull_CancelWhileProcessingPullResponse
+{
     XCTAssertEqual([self performPullWithCancellationPoint:3 serverPushResponseCode:@500 serverPullResponseCode:@500], 0, "Pull cancellation failed at cancellation point 3");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_UnsuccessfulPush_UnsuccessfulPull_CancelFromCompletionBlock
+{
     XCTAssertEqual([self performPullWithCancellationPoint:4 serverPushResponseCode:@500 serverPullResponseCode:@500], 0, "Pull cancellation failed at cancellation point 4");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_UnsuccessfulPush_UnsuccessfulPull_CancelRightAfterPullWithQueryReturns
+{
     XCTAssertEqual([self performPullWithCancellationPoint:5 serverPushResponseCode:@500 serverPullResponseCode:@500], 0, "Pull cancellation failed at cancellation point 5");
 }
 
@@ -1325,6 +1537,12 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
 // - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
 // - Verifies that the expected number of items are pull from the server
 // - Returns the number of items pulled from the server.
+// Cancellation point 0: just before the push request initiated by the pull is sent to the server
+// Cancellation point 1: immediately after receiving response for the push initiated by the pull operation
+// Cancellation point 2: just before the pull request is sent to the server
+// Cancellation point 3: immediately after receiving response for the pull request
+// Cancellation point 4: while executing the pull completion block
+// Cancellation point 5: immediately after the pull NSOperation is returned by pullWithQuery:queryId:completion:
 -(int) performPullWithCancellationPoint:(int) requestedCancellationPoint serverPushResponseCode:(NSNumber *)serverPushResponseCode serverPullResponseCode:(NSNumber *)serverPullResponseCode
 {
     // Initialization
@@ -1334,11 +1552,6 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     MSClient *filteredClient = [client clientWithFilter:filter];
     MSSyncTable *todoTable = [filteredClient syncTableWithName:TodoTableNoVersion];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoTable];
-    
-    // Start with a clean slate
-    [[todoTable forcePurgeWithCompletion:^(NSError *error) {
-        XCTAssertNil(error, @"error should have been nil.");
-    }] waitUntilFinished];
     
     __block NSOperation *pullOperation;
     

--- a/sdk/iOS/test/MSSyncTableTests.m
+++ b/sdk/iOS/test/MSSyncTableTests.m
@@ -1174,17 +1174,17 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     [self waitForExpectationsWithTimeout:10 handler:nil];
 
-    XCTAssertEqual([self performVanillaPush], 2, "Expected all inserted items to have been pushed to the server by now");
+    XCTAssertEqual([self performFollowupPushWithClient:client], 2, "Expected all inserted items to have been pushed to the server by now");
 
     return synchronizedItemCount;
 }
 
 // Performs a push operation and returns the count of all client items pushed so far
--(int) performVanillaPush
+-(int) performFollowupPushWithClient:(MSClient *)pushClient
 {
     // Define a filter that returns an appropriate server response for the requested item
     MSTestFilter *filter = [MSTestFilter new];
-    MSClient *filteredClient = [client clientWithFilter:filter];
+    MSClient *filteredClient = [pushClient clientWithFilter:filter];
 
     filter.ignoreNextFilter = YES;
     filter.onInspectResponseData = ^(NSURLRequest *request, NSData *data) {
@@ -1383,17 +1383,17 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     
     int synchronizedItemCount = [self synchronizedItemCount];
     
-    XCTAssertEqual([self performVanillaPull], 3, "Expected all server items to have been pulled to the client by now");
+    XCTAssertEqual([self performFollowupPullWithClient:client], 3, "Expected all server items to have been pulled to the client by now");
     
     return synchronizedItemCount;
 }
 
 // Performs a pull operation and returns the count of all the server items pulled so far
--(int) performVanillaPull
+-(int) performFollowupPullWithClient:(MSClient *)pullClient
 {
     // Initialization
     MSTestFilter *filter = [MSTestFilter new];
-    MSClient *filteredClient = [client clientWithFilter:filter];
+    MSClient *filteredClient = [pullClient clientWithFilter:filter];
     MSSyncTable *todoTable = [filteredClient syncTableWithName:TodoTableNoVersion];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoTable];
 

--- a/sdk/iOS/test/MSSyncTableTests.m
+++ b/sdk/iOS/test/MSSyncTableTests.m
@@ -1123,8 +1123,9 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     ((MSTestFilter *)filter.testFilters[0]).onInspectRequest = ^(NSURLRequest *request) {
 
         // Cancellation point 0
-        if (requestedCancellationPoint == 0)
+        if (requestedCancellationPoint == 0) {
             [pushOperation cancel];
+        }
         
         return request;
     };
@@ -1132,8 +1133,9 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     ((MSTestFilter *)filter.testFilters[0]).onInspectResponseData = ^(NSURLRequest *request, NSData *data) {
 
         // Cancellation point 1
-        if (requestedCancellationPoint == 1)
+        if (requestedCancellationPoint == 1) {
             [pushOperation cancel];
+        }
         
         return data;
     };
@@ -1150,13 +1152,15 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     pushOperation = [filteredClient.syncContext pushWithCompletion:^(NSError *error) {
         
         // Cancellation point 2
-        if (requestedCancellationPoint == 2)
+        if (requestedCancellationPoint == 2) {
             [pushOperation cancel];
+        }
     }];
     
     // Cancellation point 3
-    if (requestedCancellationPoint == 3)
+    if (requestedCancellationPoint == 3) {
         [pushOperation cancel];
+    }
 
     [self verifyFinished:pushOperation];
 
@@ -1320,8 +1324,9 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     ((MSTestFilter *)filter.testFilters[0]).onInspectRequest = ^(NSURLRequest *request) {
         
         // Cancellation point 0
-        if (requestedCancellationPoint == 0)
+        if (requestedCancellationPoint == 0) {
             [pullOperation cancel];
+        }
         
         return request;
     };
@@ -1329,8 +1334,9 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     ((MSTestFilter *)filter.testFilters[0]).onInspectResponseData = ^(NSURLRequest *request, NSData *data) {
         
         // Cancellation point 1
-        if (requestedCancellationPoint == 1)
+        if (requestedCancellationPoint == 1) {
             [pullOperation cancel];
+        }
         
         return data;
     };
@@ -1338,8 +1344,9 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     ((MSTestFilter *)filter.testFilters[1]).onInspectRequest = ^(NSURLRequest *request) {
         
         // Cancellation point 2
-        if (requestedCancellationPoint == 2)
+        if (requestedCancellationPoint == 2) {
             [pullOperation cancel];
+        }
         
         return request;
     };
@@ -1347,8 +1354,9 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     ((MSTestFilter *)filter.testFilters[1]).onInspectResponseData = ^(NSURLRequest *request, NSData *data) {
         
         // Cancellation point 3
-        if (requestedCancellationPoint == 3)
+        if (requestedCancellationPoint == 3) {
             [pullOperation cancel];
+        }
         
         return data;
     };
@@ -1365,13 +1373,15 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     pullOperation = [filteredClient.syncContext pullWithQuery:query queryId:nil completion:^(NSError *error) {
 
         // Cancellation point 4
-        if (requestedCancellationPoint == 4)
+        if (requestedCancellationPoint == 4) {
             [pullOperation cancel];
+        }
     }];
 
     // Cancellation point 5
-    if (requestedCancellationPoint == 5)
+    if (requestedCancellationPoint == 5) {
         [pullOperation cancel];
+    }
 
     [self verifyFinished:pullOperation];
     

--- a/sdk/iOS/test/MSSyncTableTests.m
+++ b/sdk/iOS/test/MSSyncTableTests.m
@@ -1218,23 +1218,19 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     // Initialization
     MSSyncTable *todoTable = [client syncTableWithName:TodoTableNoVersion];
     MSQuery *query = [[MSQuery alloc] initWithSyncTable:todoTable];
+    query.predicate = [NSPredicate predicateWithFormat:@"text == 'server'"];
 
     // Number synchronized items
     __block int numSynchronizedItems = 0;
-
+    
     XCTestExpectation *readExpectation = [self expectationWithDescription:@"read expectation"];
-
+    
     // Read from the table
     [client.syncContext readWithQuery:query completion:^(MSQueryResult *result, NSError *error) {
         
-        // Count the number of synchronized items
-        for (NSDictionary* item in result.items) {
-            if ([item[@"text"] isEqualToString:@"server"]) {
-                ++numSynchronizedItems;
-            }
-        }
-
+        numSynchronizedItems = result.items.count;
         [readExpectation fulfill];
+        
     }];
     
     [self waitForExpectationsWithTimeout:10 handler:nil];

--- a/sdk/iOS/test/MSSyncTableTests.m
+++ b/sdk/iOS/test/MSSyncTableTests.m
@@ -1087,17 +1087,24 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
 // - Verifies that a push following a cancelled push operation works as expected
 // - Verifies that cancelling a push operation finishes the push NSOperation regardless of the cancellation point
 // - Verifies that the expected number of items are pushed to the server
--(void) testPushCancellability
+-(void) testPushCancellability_successfulpush
 {
-    XCTAssertEqual([self performPushWithCancellationPoint:0 serverResponseCode:200], 0, "Push cancellation failed");
-    XCTAssertEqual([self performPushWithCancellationPoint:1 serverResponseCode:200], 0, "Push cancellation failed");
-    XCTAssertEqual([self performPushWithCancellationPoint:2 serverResponseCode:200], 1, "Push cancellation failed");
-    XCTAssertEqual([self performPushWithCancellationPoint:3 serverResponseCode:200], 0, "Push cancellation failed");
+    XCTAssertEqual([self performPushWithCancellationPoint:0 serverResponseCode:200], 0, "Push cancellation failed at cancellation point 0");
+    XCTAssertEqual([self performPushWithCancellationPoint:1 serverResponseCode:200], 0, "Push cancellation failed at cancellation point 1");
+    XCTAssertEqual([self performPushWithCancellationPoint:2 serverResponseCode:200], 1, "Push cancellation failed at cancellation point 2");
+    XCTAssertEqual([self performPushWithCancellationPoint:3 serverResponseCode:200], 0, "Push cancellation failed at cancellation point 3");
+}
 
-    XCTAssertEqual([self performPushWithCancellationPoint:0 serverResponseCode:500], 0, "Push cancellation failed");
-    XCTAssertEqual([self performPushWithCancellationPoint:1 serverResponseCode:500], 0, "Push cancellation failed");
-    XCTAssertEqual([self performPushWithCancellationPoint:2 serverResponseCode:500], 0, "Push cancellation failed");
-    XCTAssertEqual([self performPushWithCancellationPoint:3 serverResponseCode:500], 0, "Push cancellation failed");
+// Tests cancellation of the push operation at various stages of a push workflow.
+// - Verifies that a push following a cancelled push operation works as expected
+// - Verifies that cancelling a push operation finishes the push NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pushed to the server
+-(void) testPushCancellability_unsuccessfulpush
+{
+    XCTAssertEqual([self performPushWithCancellationPoint:0 serverResponseCode:500], 0, "Push cancellation failed at cancellation point 0");
+    XCTAssertEqual([self performPushWithCancellationPoint:1 serverResponseCode:500], 0, "Push cancellation failed at cancellation point 1");
+    XCTAssertEqual([self performPushWithCancellationPoint:2 serverResponseCode:500], 0, "Push cancellation failed at cancellation point 2");
+    XCTAssertEqual([self performPushWithCancellationPoint:3 serverResponseCode:500], 0, "Push cancellation failed at cancellation point 3");
 }
 
 // Performs push and cancels it at the specified cancellation point.
@@ -1261,37 +1268,56 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
 // - Verifies that a pull operation following a cancelled pull operation works as expected
 // - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
 // - Verifies that the expected number of items are pulled from the server
--(void) testPullCancellability
+-(void) testPullCancellability_successfulpush_successfulpull
 {
-    XCTAssertEqual([self performPullWithCancellationPoint:0 serverPushResponseCode:@200 serverPullResponseCode:@200], 1, "Pull cancellation failed");
-    XCTAssertEqual([self performPullWithCancellationPoint:1 serverPushResponseCode:@200 serverPullResponseCode:@200], 1, "Pull cancellation failed");
-    XCTAssertEqual([self performPullWithCancellationPoint:2 serverPushResponseCode:@200 serverPullResponseCode:@200], 1, "Pull cancellation failed");
-    XCTAssertEqual([self performPullWithCancellationPoint:3 serverPushResponseCode:@200 serverPullResponseCode:@200], 1, "Pull cancellation failed");
-    XCTAssertEqual([self performPullWithCancellationPoint:4 serverPushResponseCode:@200 serverPullResponseCode:@200], 2, "Pull cancellation failed");
-    XCTAssertEqual([self performPullWithCancellationPoint:5 serverPushResponseCode:@200 serverPullResponseCode:@200], 1, "Pull cancellation failed");
-   
-    XCTAssertEqual([self performPullWithCancellationPoint:0 serverPushResponseCode:@200 serverPullResponseCode:@500], 1, "Pull cancellation failed");
-    XCTAssertEqual([self performPullWithCancellationPoint:1 serverPushResponseCode:@200 serverPullResponseCode:@500], 1, "Pull cancellation failed");
-    XCTAssertEqual([self performPullWithCancellationPoint:2 serverPushResponseCode:@200 serverPullResponseCode:@500], 1, "Pull cancellation failed");
-    XCTAssertEqual([self performPullWithCancellationPoint:3 serverPushResponseCode:@200 serverPullResponseCode:@500], 1, "Pull cancellation failed");
-    XCTAssertEqual([self performPullWithCancellationPoint:4 serverPushResponseCode:@200 serverPullResponseCode:@500], 1, "Pull cancellation failed");
-    XCTAssertEqual([self performPullWithCancellationPoint:5 serverPushResponseCode:@200 serverPullResponseCode:@500], 1, "Pull cancellation failed");
-    
-    XCTAssertEqual([self performPullWithCancellationPoint:0 serverPushResponseCode:@500 serverPullResponseCode:@200], 0, "Pull cancellation failed");
-    XCTAssertEqual([self performPullWithCancellationPoint:1 serverPushResponseCode:@500 serverPullResponseCode:@200], 0, "Pull cancellation failed");
-    XCTAssertEqual([self performPullWithCancellationPoint:2 serverPushResponseCode:@500 serverPullResponseCode:@200], 0, "Pull cancellation failed");
-    XCTAssertEqual([self performPullWithCancellationPoint:3 serverPushResponseCode:@500 serverPullResponseCode:@200], 0, "Pull cancellation failed");
-    XCTAssertEqual([self performPullWithCancellationPoint:4 serverPushResponseCode:@500 serverPullResponseCode:@200], 0, "Pull cancellation failed");
-    XCTAssertEqual([self performPullWithCancellationPoint:5 serverPushResponseCode:@500 serverPullResponseCode:@200], 0, "Pull cancellation failed");
-    
-    XCTAssertEqual([self performPullWithCancellationPoint:0 serverPushResponseCode:@500 serverPullResponseCode:@500], 0, "Pull cancellation failed");
-    XCTAssertEqual([self performPullWithCancellationPoint:1 serverPushResponseCode:@500 serverPullResponseCode:@500], 0, "Pull cancellation failed");
-    XCTAssertEqual([self performPullWithCancellationPoint:2 serverPushResponseCode:@500 serverPullResponseCode:@500], 0, "Pull cancellation failed");
-    XCTAssertEqual([self performPullWithCancellationPoint:3 serverPushResponseCode:@500 serverPullResponseCode:@500], 0, "Pull cancellation failed");
-    XCTAssertEqual([self performPullWithCancellationPoint:4 serverPushResponseCode:@500 serverPullResponseCode:@500], 0, "Pull cancellation failed");
-    XCTAssertEqual([self performPullWithCancellationPoint:5 serverPushResponseCode:@500 serverPullResponseCode:@500], 0, "Pull cancellation failed");
-    
-    [self performPullWithCancellationPoint:0 serverPushResponseCode:@500 serverPullResponseCode:@200];
+    XCTAssertEqual([self performPullWithCancellationPoint:0 serverPushResponseCode:@200 serverPullResponseCode:@200], 1, "Pull cancellation failed at cancellation point 0");
+    XCTAssertEqual([self performPullWithCancellationPoint:1 serverPushResponseCode:@200 serverPullResponseCode:@200], 1, "Pull cancellation failed at cancellation point 1");
+    XCTAssertEqual([self performPullWithCancellationPoint:2 serverPushResponseCode:@200 serverPullResponseCode:@200], 1, "Pull cancellation failed at cancellation point 2");
+    XCTAssertEqual([self performPullWithCancellationPoint:3 serverPushResponseCode:@200 serverPullResponseCode:@200], 1, "Pull cancellation failed at cancellation point 3");
+    XCTAssertEqual([self performPullWithCancellationPoint:4 serverPushResponseCode:@200 serverPullResponseCode:@200], 2, "Pull cancellation failed at cancellation point 4");
+    XCTAssertEqual([self performPullWithCancellationPoint:5 serverPushResponseCode:@200 serverPullResponseCode:@200], 1, "Pull cancellation failed at cancellation point 5");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_successfulpush_unsuccessfulpull
+{
+    XCTAssertEqual([self performPullWithCancellationPoint:0 serverPushResponseCode:@200 serverPullResponseCode:@500], 1, "Pull cancellation failed at cancellation point 0");
+    XCTAssertEqual([self performPullWithCancellationPoint:1 serverPushResponseCode:@200 serverPullResponseCode:@500], 1, "Pull cancellation failed at cancellation point 1");
+    XCTAssertEqual([self performPullWithCancellationPoint:2 serverPushResponseCode:@200 serverPullResponseCode:@500], 1, "Pull cancellation failed at cancellation point 2");
+    XCTAssertEqual([self performPullWithCancellationPoint:3 serverPushResponseCode:@200 serverPullResponseCode:@500], 1, "Pull cancellation failed at cancellation point 3");
+    XCTAssertEqual([self performPullWithCancellationPoint:4 serverPushResponseCode:@200 serverPullResponseCode:@500], 1, "Pull cancellation failed at cancellation point 4");
+    XCTAssertEqual([self performPullWithCancellationPoint:5 serverPushResponseCode:@200 serverPullResponseCode:@500], 1, "Pull cancellation failed at cancellation point 5");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_unsuccessfulpush_successfulpull
+{
+    XCTAssertEqual([self performPullWithCancellationPoint:0 serverPushResponseCode:@500 serverPullResponseCode:@200], 0, "Pull cancellation failed at cancellation point 0");
+    XCTAssertEqual([self performPullWithCancellationPoint:1 serverPushResponseCode:@500 serverPullResponseCode:@200], 0, "Pull cancellation failed at cancellation point 1");
+    XCTAssertEqual([self performPullWithCancellationPoint:2 serverPushResponseCode:@500 serverPullResponseCode:@200], 0, "Pull cancellation failed at cancellation point 2");
+    XCTAssertEqual([self performPullWithCancellationPoint:3 serverPushResponseCode:@500 serverPullResponseCode:@200], 0, "Pull cancellation failed at cancellation point 3");
+    XCTAssertEqual([self performPullWithCancellationPoint:4 serverPushResponseCode:@500 serverPullResponseCode:@200], 0, "Pull cancellation failed at cancellation point 4");
+    XCTAssertEqual([self performPullWithCancellationPoint:5 serverPushResponseCode:@500 serverPullResponseCode:@200], 0, "Pull cancellation failed at cancellation point 5");
+}
+
+// Tests cancellation of the pull operation at various stages of the pull workflow
+// - Verifies that a pull operation following a cancelled pull operation works as expected
+// - Verifies that cancelling a pull operation finishes the pull NSOperation regardless of the cancellation point
+// - Verifies that the expected number of items are pulled from the server
+-(void) testPullCancellability_unsuccessfulpush_unsuccessfulpull
+{
+    XCTAssertEqual([self performPullWithCancellationPoint:0 serverPushResponseCode:@500 serverPullResponseCode:@500], 0, "Pull cancellation failed at cancellation point 0");
+    XCTAssertEqual([self performPullWithCancellationPoint:1 serverPushResponseCode:@500 serverPullResponseCode:@500], 0, "Pull cancellation failed at cancellation point 1");
+    XCTAssertEqual([self performPullWithCancellationPoint:2 serverPushResponseCode:@500 serverPullResponseCode:@500], 0, "Pull cancellation failed at cancellation point 2");
+    XCTAssertEqual([self performPullWithCancellationPoint:3 serverPushResponseCode:@500 serverPullResponseCode:@500], 0, "Pull cancellation failed at cancellation point 3");
+    XCTAssertEqual([self performPullWithCancellationPoint:4 serverPushResponseCode:@500 serverPullResponseCode:@500], 0, "Pull cancellation failed at cancellation point 4");
+    XCTAssertEqual([self performPullWithCancellationPoint:5 serverPushResponseCode:@500 serverPullResponseCode:@500], 0, "Pull cancellation failed at cancellation point 5");
 }
 
 // Performs pull and cancels it at the specified cancellation point.


### PR DESCRIPTION
- Added UTs to test cancellability of push and pull operations at various execution points
- Removed UT testPullResultingInErrorAllowsDependentOperationsToComplete as completion of push/pull operation is covered by the newly added UTs