### PR TITLE
[iOS] added property to turn off data store handling table operations

### DIFF
--- a/sdk/iOS/src/MSCoreDataStore.h
+++ b/sdk/iOS/src/MSCoreDataStore.h
@@ -25,6 +25,12 @@
 
 /// @}
 
+/// Disables the store from recieving information about the items passed into all sync table
+/// calls (insert, delete, update). If set, the application is responsible for already having
+/// saved the item in the persisten store. This flag is intended to be used when application
+/// code is working directly with NSManagedObjects.
+@property (nonatomic) BOOL handlesSyncTableOperations;
+
 #pragma mark * Helper functions
 
 /// @{name Working with the table APIs

--- a/sdk/iOS/src/MSCoreDataStore.m
+++ b/sdk/iOS/src/MSCoreDataStore.m
@@ -22,6 +22,7 @@ NSString *const StoreDeleted = @"ms_deleted";
     self = [super init];
     if (self) {
         self.context = context;
+		self.handlesSyncTableOperations = YES;
     }
     return self;
 }

--- a/sdk/iOS/src/MSSyncContext.h
+++ b/sdk/iOS/src/MSSyncContext.h
@@ -56,6 +56,10 @@ typedef void (^MSSyncPushCompletionBlock)(void);
 /// Provides the name of the table to track configuration data
 - (NSString *) configTableName;
 
+/// Indicates if the items passed to a sync table call should be saved by the SDK, if disabled, the local store will only
+/// recieve upserts/deletes for data calls originating from the server (pulls & pushes) plus the state tracking on the operation queue.
+@property (nonatomic) BOOL handlesSyncTableOperations;
+
 /// @}
 
 /// @name Fetching and Retrieving Data

--- a/sdk/iOS/src/MSSyncContext.m
+++ b/sdk/iOS/src/MSSyncContext.m
@@ -159,7 +159,7 @@ static NSOperationQueue *pushQueue_;
         }
         
         // Update local store and then the operation queue
-        if (error == nil) {
+        if (error == nil && self.dataSource.handlesSyncTableOperations) {
             switch (action) {
                 case MSTableOperationInsert: {
                     // Check to see if this item already exists


### PR DESCRIPTION
Used for custom implementation of data insertion and requiring the sync context to only handle server message creation

This is the same change as #707 downloaded as a git patch and applied to the dev branch.