### PR TITLE
Add support for NSUUID in MSPredicateTranslator

### DIFF
--- a/sdk/iOS/src/MSPredicateTranslator.m
+++ b/sdk/iOS/src/MSPredicateTranslator.m
@@ -69,6 +69,7 @@ static NSString *const dateTimeConstant = @"datetime'%@'";
 static NSString *const dateTimeOffsetConstant = @"datetimeoffset'%@'";
 static NSString *const alwaysTrueConstant = @"(1 eq 1)";
 static NSString *const alwaysFalseConstant = @"(1 eq 0)";
+static NSString *const guidConstant = @"guid'%@'";
 
 
 #pragma mark * MSPredicateTranslator Implementation
@@ -547,6 +548,9 @@ static NSDictionary *staticFunctionInfoLookup;
         // Except for decimals, all number types and bools will be this case
         result = [MSPredicateTranslator visitNumberConstant:constant];
     }
+    else if ([constant isKindOfClass:[NSUUID class]]) {
+        result = [MSPredicateTranslator visitGuidConstant:constant];
+    }
     
     return result;
 }
@@ -623,6 +627,11 @@ static NSDictionary *staticFunctionInfoLookup;
     } 
 
     return result;
+}
+
++(NSString *) visitGuidConstant:(NSUUID *) guid
+{
+    return [NSString stringWithFormat:guidConstant, guid.UUIDString];
 }
 
 +(NSDictionary *) functionInfoLookup

--- a/sdk/iOS/test/MSPredicateTranslatorTests.m
+++ b/sdk/iOS/test/MSPredicateTranslatorTests.m
@@ -26,6 +26,8 @@
     dateParts.second = 29;
     NSDate *date2 = dateParts.date;
     NSDate *date3 = [date2 dateByAddingTimeInterval:0.3];
+    
+    NSUUID *guid = [[NSUUID alloc] initWithUUIDString: @"01234567-89ab-cdef-0123-456789abcdef"];
 
     // For each test case: the first element is the expected OData value;
     // the second element is the predicate format string; and all
@@ -146,6 +148,9 @@
     
         @[ @"((Zipcode eq (98007 add 1)) or (Zipcode eq (98007 sub 1)) or (Zipcode eq 98007))",
            @"Zipcode IN { %@ + 1, %@ - 1, %@ }", @98007, @98007, @98007],
+        
+        @[ @"(Id eq guid'01234567-89AB-CDEF-0123-456789ABCDEF')",
+           @"Id == %@", guid ],
     ];
     
     for (NSArray *testCase in testCases) {


### PR DESCRIPTION
This will enable creating ODATA queries with guid objects in the query string.

Per: http://azure.github.io/guidelines.html#contributing
I work for Microsoft and I may not need to sign CLA. 
MS Alias: abhiku
