### PR TITLE
iOS: Fix incorrect error on insert with generated ids

### DIFF
--- a/sdk/iOS/src/MSSyncContext.m
+++ b/sdk/iOS/src/MSSyncContext.m
@@ -161,14 +161,14 @@ static NSOperationQueue *pushQueue_;
             switch (action) {
                 case MSTableOperationInsert: {
                     // Check to see if this item already exists
-                    NSString *itemId = item[MSSystemColumnId];
+                    NSString *itemId = itemToSave[MSSystemColumnId];
                     NSDictionary *result = [self syncTable:table readWithId:itemId orError:&error];
                     if (error == nil) {
                         if (result == nil) {
                             [self.dataSource upsertItems:@[itemToSave] table:table orError:&error];
-                        }
-                        else {
-                            error = [self errorWithDescription:@"This item already exists." andErrorCode:MSSyncTableInvalidAction];
+                        } else {
+                            error = [self errorWithDescription:@"This item already exists."
+                                                  andErrorCode:MSSyncTableInvalidAction];
                         }
                     }
                     break;

--- a/sdk/iOS/test/MSSyncTableTests.m
+++ b/sdk/iOS/test/MSSyncTableTests.m
@@ -101,6 +101,29 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
     XCTAssertEqualObjects(newItem[@"text"], item[@"text"]);
 }
 
+-(void) testInsertItemWithNoIdAndNilIdRecordExistsSuccess
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:self.name];
+
+    // Place record with a id of nil, to ensure the id check is using an actual value for id
+    [offline upsertItems:@[ @{ @"text":@"record with nil id" } ]
+                   table:TodoTableNoVersion
+                 orError:nil];
+    
+    MSSyncTable *todoTable = [client syncTableWithName:TodoTableNoVersion];
+    
+    id item = @{ @"text":@"test name" };
+    [todoTable insert:item completion:^(NSDictionary *item, NSError *error) {
+        // If the id check used nil, we would have gotten an error that the id was in use
+        XCTAssertNil(error);
+        XCTAssertNotNil(item[@"id"], @"The item should have an id");
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+
+
 -(void) testInsertItemWithInvalidId
 {
     XCTestExpectation *expectation = [self expectationWithDescription:self.name];


### PR DESCRIPTION
Previously, a sync table’s insert check to see if an id was in use would not work as intended if the id was auto generated.  This should've only caused an issue if the table had a record with no id or if the GUID randomly generated did actually have a conflict.