### PR TITLE
[iOS] Update build process to include BitCode, fix include issue

### DIFF
--- a/CHANGELOG.ios.md
+++ b/CHANGELOG.ios.md
@@ -4,6 +4,10 @@
 - [Latest iOS 2.x SDK](http://aka.ms/gc6fex)
 - [iOS 1.2.4 SDK](http://aka.ms/kymw2g)
 
+### Version 2.2.2
+- Fixed issue with MSCoreDataStore.h that prevented it from bring used as part of a cocapod
+- Updated build tooling to use XCode 7 and include BitCode [issue #794](https://github.com/Azure/azure-mobile-services/issues/794)
+
 ### Version 2.2.1
 - Fixed [issue #768](https://github.com/Azure/azure-mobile-services/issues/768) that was causing a memory leak when using NSURLSession [204f210](https://github.com/Azure/azure-mobile-services/commit/204f210)
 - Fix NSNull templateName [9347390](https://github.com/Azure/azure-mobile-services/commit/9347390)
@@ -54,7 +58,7 @@
 
 ### Version 1.2.3
 - Fix issue with const when using both Azure Messaging and Mobile Services frameworks
-- Fix issue [#306](https://github.com/Azure/azure-mobile-services/issues/306) with how arrays passed as query string params to table and custom APIs are converted 
+- Fix issue [#306](https://github.com/Azure/azure-mobile-services/issues/306) with how arrays passed as query string params to table and custom APIs are converted
 - Fix issue where system properties (__version, __updatedAt, etc) were returned to the caller when they were not requested
 
 ### Version 1.2.2
@@ -69,7 +73,7 @@
 
 ### Version 1.1.2
 - Supports the arm64 architecture
-- Now requires iOS 6 or newer to use 
+- Now requires iOS 6 or newer to use
 
 ### Version 1.1.1
 - Support for optimistic concurrency (version / ETag) validation
@@ -78,4 +82,3 @@
 
 ### Version 1.1.0
 - Support for tables with string ids
-

--- a/CHANGELOG.ios.md
+++ b/CHANGELOG.ios.md
@@ -2,11 +2,13 @@
 
 ## SDK Downloads
 - [Latest iOS 2.x SDK](http://aka.ms/gc6fex)
+ - **requires XCode 7**
 - [iOS 1.2.4 SDK](http://aka.ms/kymw2g)
 
 ### Version 2.2.2
-- Fixed issue with MSCoreDataStore.h that prevented it from bring used as part of a cocapod
 - Updated build tooling to use XCode 7 and include BitCode [issue #794](https://github.com/Azure/azure-mobile-services/issues/794)
+ - Note: Framework now requires using XCode 7
+- Fixed issue with MSCoreDataStore.h that prevented it from bring used as part of a cocoapod
 
 ### Version 2.2.1
 - Fixed [issue #768](https://github.com/Azure/azure-mobile-services/issues/768) that was causing a memory leak when using NSURLSession [204f210](https://github.com/Azure/azure-mobile-services/commit/204f210)

--- a/sdk/iOS/build.command
+++ b/sdk/iOS/build.command
@@ -21,7 +21,7 @@ if [ "$SET_BUILD_VERSION" == "YES" ]; then
 fi
 
 # Build the framework
-xcodebuild -target Framework OBJROOT=./Build SYMROOT=./Build
+xcodebuild OTHER_CFLAGS="-fembed-bitcode" -target Framework OBJROOT=./Build SYMROOT=./Build
 
 # Move back to the original WindowsAzureMobileServices.h file
 if [ "$SET_BUILD_VERSION" == "YES" ]; then
@@ -35,7 +35,7 @@ rsync -rlK ../../sdk/iOS/Build/Release-iphoneos/WindowsAzureMobileServices.frame
 cp license.rtf WindowsAzureMobileServices.framework
 
 # Zip the framework
-zip -r WindowsAzureMobileServices.framework.zip WindowsAzureMobileServices.framework 
+zip -r WindowsAzureMobileServices.framework.zip WindowsAzureMobileServices.framework
 
 # Lastly, copy to the build share
 if [ "$COPY_TO_SHARE" == "YES" ]; then
@@ -44,4 +44,4 @@ if [ "$COPY_TO_SHARE" == "YES" ]; then
   do
     rsync -rlK WindowsAzureMobileServices.framework.zip $SHARE_PATH
   done
-fi 
+fi

--- a/sdk/iOS/build.command
+++ b/sdk/iOS/build.command
@@ -21,7 +21,7 @@ if [ "$SET_BUILD_VERSION" == "YES" ]; then
 fi
 
 # Build the framework
-xcodebuild OTHER_CFLAGS="-fembed-bitcode" -target Framework OBJROOT=./Build SYMROOT=./Build
+xcodebuild OTHER_CFLAGS="-fembed-bitcode -miphoneos-version-min=7.0" -target Framework OBJROOT=./Build SYMROOT=./Build
 
 # Move back to the original WindowsAzureMobileServices.h file
 if [ "$SET_BUILD_VERSION" == "YES" ]; then

--- a/sdk/iOS/src/MSCoreDataStore.h
+++ b/sdk/iOS/src/MSCoreDataStore.h
@@ -3,8 +3,8 @@
 // ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import <WindowsAzureMobileServices/WindowsAzureMobileServices.h>
 #import <CoreData/CoreData.h>
+#import "MSSyncContext.h"
 
 /// The MSCoreDataStore class is for use when using the offline capabilities
 /// of mobile services. This class is a local store which manages records and sync

--- a/sdk/iOS/src/MSCoreDataStore.m
+++ b/sdk/iOS/src/MSCoreDataStore.m
@@ -3,6 +3,11 @@
 // ----------------------------------------------------------------------------
 
 #import "MSCoreDataStore.h"
+#import "MSTable.h"
+#import "MSSyncTable.h"
+#import "MSQuery.h"
+#import "MSSyncContextReadResult.h"
+#import "MSError.h"
 
 NSString *const SystemColumnPrefix = @"__";
 NSString *const StoreSystemColumnPrefix = @"ms_";


### PR DESCRIPTION
Updates the build command to include BitCode in the generated framework

Fixes an include issue in MSCoreDataStore that stopped it from being used via a cocoapod