### PR TITLE
[Cordova] First set of changes for offline sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,5 @@ packages
 *.jar
 *.xccheckout
 deriveddata
-
+.vs
 *.iml

--- a/sdk/Javascript/package.json
+++ b/sdk/Javascript/package.json
@@ -2,10 +2,18 @@
   "name": "AzureMobileServices",
   "version": "2.0.0-beta",
   "devDependencies": {
+    "browserify": "~11.1.0",
     "grunt": "~0.4.5",
+    "grunt-browserify": "~4.0.1",
+    "grunt-contrib-concat": "~0.5.0",
+    "grunt-contrib-copy": "~0.8.1",
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-nodeunit": "~0.4.1",
     "grunt-contrib-uglify": "~0.6.0",
-    "grunt-contrib-concat": "~0.5.0"
+    "grunt-contrib-concat": "~0.5.0",
+    "grunt-contrib-copy": "~0.8.1",
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-exec": "~0.4.6",
+    "qunitjs": "~1.19.0"
   }
 }

--- a/sdk/Javascript/src/Microsoft.WindowsAzure.Mobile.JS.csproj
+++ b/sdk/Javascript/src/Microsoft.WindowsAzure.Mobile.JS.csproj
@@ -177,7 +177,10 @@
     <Content Include="MobileServiceLogin.js" />
     <Content Include="MobileServices.intellisense.js" />
     <Content Include="MobileServices.priconfig.xml" />
+    <Content Include="MobileServiceSyncContext.js" />
+    <Content Include="MobileServiceSyncTable.js" />
     <Content Include="MobileServiceTable.js" />
+    <Content Include="Platforms\cordova\MobileServiceSQLiteStore.js" />
     <Content Include="Platforms\Platform.Web.js" />
     <Content Include="Platforms\Platform.WinJS.js" />
     <Content Include="Push\Push.js" />

--- a/sdk/Javascript/src/MobileServiceClient.js
+++ b/sdk/Javascript/src/MobileServiceClient.js
@@ -9,6 +9,8 @@
 var _ = require('Extensions');
 var Validate = require('Validate');
 var Platform = require('Platform');
+var MobileServiceSyncContext = require('MobileServiceSyncContext').MobileServiceSyncContext;
+var MobileServiceSyncTable = require('MobileServiceSyncTable').MobileServiceSyncTable;
 var MobileServiceTable = require('MobileServiceTable').MobileServiceTable;
 var MobileServiceLogin = require('MobileServiceLogin').MobileServiceLogin;
 
@@ -59,6 +61,16 @@ function MobileServiceClient(applicationUrl, gatewayUrl, applicationKey) {
     this._serviceFilter = null;
     this._login = new MobileServiceLogin(this);
 
+    var _syncContext = new MobileServiceSyncContext(this);
+
+    this.getSyncContext = function() {
+        /// <summary>
+        /// Returns the associated MobileServiceSyncContext
+        /// </summary>
+
+        return _syncContext;
+    };
+
     this.getTable = function (tableName) {
         /// <summary>
         /// Gets a reference to a table and its data operations.
@@ -69,6 +81,19 @@ function MobileServiceClient(applicationUrl, gatewayUrl, applicationKey) {
         Validate.isString(tableName, 'tableName');
         Validate.notNullOrEmpty(tableName, 'tableName');
         return new MobileServiceTable(tableName, this);
+    };
+
+    this.getSyncTable = function (tableName) {
+        /// <summary>
+        /// Gets a reference to a sync table and its data operations.
+        /// </summary>
+        /// <param name="tableName">The name of the table.</param>
+        /// <returns>A reference to the sync table.</returns>
+
+        Validate.isString(tableName, 'tableName');
+        Validate.notNullOrEmpty(tableName, 'tableName');
+		
+        return new MobileServiceSyncTable(tableName, this);
     };
 
     if (Push) {

--- a/sdk/Javascript/src/MobileServiceSyncContext.js
+++ b/sdk/Javascript/src/MobileServiceSyncContext.js
@@ -1,0 +1,146 @@
+﻿// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+/// <reference path="C:\Program Files (x86)\Microsoft SDKs\Windows\v8.0\ExtensionSDKs\Microsoft.WinJS.1.0\1.0\DesignTime\CommonConfiguration\Neutral\Microsoft.WinJS.1.0\js\base.js" />
+/// <reference path="C:\Program Files (x86)\Microsoft SDKs\Windows\v8.0\ExtensionSDKs\Microsoft.WinJS.1.0\1.0\DesignTime\CommonConfiguration\Neutral\Microsoft.WinJS.1.0\js\ui.js" />
+/// <reference path="Generated\MobileServices.DevIntellisense.js" />
+
+var Validate = require('Validate');
+var Platform = require('Platform');
+var _ = require('Extensions');
+
+function MobileServiceSyncContext(client) {
+    /// <summary>
+    /// Creates an instance of the MobileServiceSyncContext class
+    /// </summary>
+    /// <param name="client" type="MobileServiceClient" mayBeNull="false">
+    /// The MobileServiceClient used to make requests.
+    /// </param>
+
+    Validate.notNull(client, 'client');
+
+    var _store;
+
+    this.initialize = function (store) {
+        /// <summary>
+        /// Initializes the sync context with an instance of the store to be used
+        /// </summary>
+
+        Validate.notNull(store);
+
+        _store = store;
+    };
+
+    // TODO(shrirs): Add tracking operations to the operations table for insert/update/delete
+    this.insert = function (tableName, instance) {
+        /// <summary>
+        /// Insert a new object into the given sync table.
+        /// </summary>
+        /// <param name="tableName" type="string">
+        /// Name of the sync table in which the object is to be inserted
+        /// </param>
+        /// <param name="instance" type="Object">
+        /// The object to be inserted into the table.
+        /// </param>
+        /// <returns type="Promise">
+        /// A promise that is resolved with the inserted object when the operation is completed successfully.
+        /// If the operation fails, the promise is rejected
+        /// </returns>
+
+        Validate.isString(tableName, 'tableName');
+        Validate.notNullOrEmpty(tableName, 'tableName');
+
+        Validate.notNull(instance, 'instance');
+        Validate.notNull(instance.id, 'instance.id'); //TODO(shrirs): instance.id is a valid scenario, handle it
+
+        Validate.notNull(_store, '_store');
+
+        return _store.lookup(tableName, instance.id).then(function(result) {
+            if (result !== null) {
+                throw "An object with the same ID already exists in the table";
+            }
+
+            _store.upsert(tableName, instance);
+        }).then(function() {
+            return instance;
+        });
+    };
+
+    this.update = function (tableName, instance) {
+        /// <summary>
+        /// Update an object in the given sync table.
+        /// </summary>
+        /// <param name="tableName" type="string">
+        /// Name of the sync table in which the object is to be updated
+        /// </param>
+        /// <param name="instance" type="Object">
+        /// The object to be updated
+        /// </param>
+        /// <returns type="Promise">
+        /// A promise that is resolved when the operation is completed successfully.
+        /// If the operation fails, the promise is rejected
+        /// </returns>
+
+        Validate.isString(tableName, 'tableName');
+        Validate.notNullOrEmpty(tableName, 'tableName');
+
+        Validate.notNull(instance, 'instance');
+        Validate.notNull(instance.id, 'instance.id');
+
+        Validate.notNull(_store, '_store');
+
+        return _store.upsert(tableName, instance);
+    };
+
+    this.lookup = function (tableName, id) {
+        /// <summary>
+        /// Gets an object from the given sync table.
+        /// </summary>
+        /// <param name="tableName" type="string">
+        /// Name of the sync table to be used for performing the object lookup
+        /// </param>
+        /// <param name="id" type="string">
+        /// The id of the object to get from the table.
+        /// </param>
+        /// <returns type="Promise">
+        /// A promise that is resolved with the looked up object when the operation is completed successfully.
+        /// If the operation fails, the promise is rejected
+        /// </returns>
+
+        Validate.isString(tableName, 'tableName');
+        Validate.notNullOrEmpty(tableName, 'tableName');
+
+        Validate.notNull(id, 'id');
+
+        Validate.notNull(_store, '_store');
+
+        return _store.lookup(tableName, id);
+    };
+
+    this.del = function (tableName, instance) {
+        /// <summary>
+        /// Delete an object from the given sync table
+        /// </summary>
+        /// <param name="tableName" type="string">
+        /// Name of the sync table to delete the object from
+        /// </param>
+        /// <param name="instance" type="Object">
+        /// The object to delete from the sync table.
+        /// </param>
+        /// <returns type="Promise">
+        /// A promise that is resolved when the operation is completed successfully.
+        /// If the operation fails, the promise is rejected
+        /// </returns>
+
+        Validate.isString(tableName, 'tableName');
+        Validate.notNullOrEmpty(tableName, 'tableName');
+
+        Validate.notNull(instance);
+        Validate.notNull(instance.id);
+
+        return _store.del(tableName, instance);
+    };
+}
+
+exports.MobileServiceSyncContext = MobileServiceSyncContext;

--- a/sdk/Javascript/src/MobileServiceSyncTable.js
+++ b/sdk/Javascript/src/MobileServiceSyncTable.js
@@ -1,0 +1,112 @@
+﻿// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+/// <reference path="C:\Program Files (x86)\Microsoft SDKs\Windows\v8.0\ExtensionSDKs\Microsoft.WinJS.1.0\1.0\DesignTime\CommonConfiguration\Neutral\Microsoft.WinJS.1.0\js\base.js" />
+/// <reference path="C:\Program Files (x86)\Microsoft SDKs\Windows\v8.0\ExtensionSDKs\Microsoft.WinJS.1.0\1.0\DesignTime\CommonConfiguration\Neutral\Microsoft.WinJS.1.0\js\ui.js" />
+/// <reference path="Generated\MobileServices.DevIntellisense.js" />
+
+var Validate = require('Validate');
+var Platform = require('Platform');
+
+function MobileServiceSyncTable(tableName, client) {
+    /// <summary>
+    /// Creates an instance of the MobileServiceSyncTable class.
+    /// </summary>
+    /// <param name="tableName" type="String">
+    /// Name of the table.
+    /// </param>
+    /// <param name="client" type="MobileServiceClient">
+    /// The MobileServiceClient used to make requests.
+    /// </param>
+
+    Validate.isString(tableName, 'tableName');
+    Validate.notNullOrEmpty(tableName, 'tableName');
+
+    Validate.notNull(client, 'client');
+
+    this.getTableName = function () {
+        /// <summary>
+        /// Gets the name of the table.
+        /// </summary>
+        /// <returns type="String">The name of the table.</returns>
+
+        return tableName;
+    };
+
+    this.getClient = function () {
+        /// <summary>
+        /// Gets the MobileServiceClient associated with this table.
+        /// </summary>
+        /// <returns type="MobileServiceClient">
+        /// The MobileServiceClient associated with this table.
+        /// </returns>
+
+        return client;
+    };
+
+    this.insert = function (instance) {
+        /// <summary>
+        /// Insert a new object into the sync table.
+        /// </summary>
+        /// <param name="instance" type="Object">
+        /// The object to insert into the table.
+        /// </param>
+        /// <returns type="Promise">
+        /// A promise that is resolved with the inserted object when the operation is completed successfully.
+        /// If the operation fails, the promise is rejected
+        /// </returns>
+
+        return client.getSyncContext().insert(tableName, instance);
+    };
+
+    this.update = function (instance) {
+        /// <summary>
+        /// Update an object in the sync table.
+        /// </summary>
+        /// <param name="instance" type="Object">
+        /// The object to update
+        /// </param>
+        /// <returns type="Promise">
+        /// A promise that is resolved when the operation is completed successfully.
+        /// If the operation fails, the promise is rejected
+        /// </returns>
+
+        return client.getSyncContext().update(tableName, instance);
+    };
+
+    this.lookup = function (id) {
+        /// <summary>
+        /// Gets an object from the sync table.
+        /// </summary>
+        /// <param name="id" type="string">
+        /// The id of the object to get from the table.
+        /// </param>
+        /// <returns type="Promise">
+        /// A promise that is resolved with the looked up object when the operation is completed successfully.
+        /// If the operation fails, the promise is rejected
+        /// </returns>
+
+        return client.getSyncContext().lookup(tableName, id);
+    };
+
+    this.del = function (instance) {
+        /// <summary>
+        /// Delete an object from the sync table
+        /// </summary>
+        /// <param name="instance" type="Object">
+        /// The instance to delete from the sync table.
+        /// </param>
+        /// <returns type="Promise">
+        /// A promise that is resolved when the operation is completed successfully.
+        /// If the operation fails, the promise is rejected
+        /// </returns>
+
+        return client.getSyncContext().del(tableName, instance);
+    };
+
+}
+
+// Export the MobileServiceSyncTable class
+exports.MobileServiceSyncTable = MobileServiceSyncTable;
+    

--- a/sdk/Javascript/src/Platforms/cordova/MobileServiceSQLiteStore.js
+++ b/sdk/Javascript/src/Platforms/cordova/MobileServiceSQLiteStore.js
@@ -1,0 +1,241 @@
+﻿// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+var Platform = require('Platform');
+var Validate = require('Validate');
+var _ = require('Extensions');
+
+var idPropertyName = "id";
+var tables = {};
+
+var MobileServiceSQLiteStore = function (dbName) {
+    /// <summary>
+    /// Initializes a new instance of the MobileServiceSQLiteStore class.
+    /// </summary>
+
+    this._db = window.sqlitePlugin.openDatabase({ name: dbName });
+
+    this.defineTable = Platform.async(function (tableDefinition, callback) {
+        /// <summary>Defines the local table in the sqlite store</summary>
+        /// <param name="tableDefinition">Table definition object defining the table name and columns
+        /// Example of a valid tableDefinition object:
+        /// tableDefinition : {
+        ///     name: "todoItemTable",
+        ///     columnDefinitions : {
+        ///         id : "INTEGER",
+        ///         description : MobileServiceSQLiteStore.ColumnType.TEXT,
+        ///         price : "REAL"
+        ///     }
+        /// }
+        /// </param>
+        /// <returns type="Promise">
+        /// A promise that is resolved when the operation is completed successfully.
+        /// If the operation fails, the promise is rejected
+        /// </returns>
+
+        // Platform.async silently appends a callback argument to the original list of arguments.
+        // Validate the argument length to ensure the callback argument is indeed the callback 
+        // provided by Platform.async.
+        Validate.length(arguments, 2, 'arguments');
+
+        Validate.notNull(callback, 'callback');
+
+        Validate.notNull(tableDefinition, 'tableDefinition');
+        Validate.isString(tableDefinition.name, 'tableDefinition.name');
+        Validate.notNullOrEmpty(tableDefinition.name, 'tableDefinition.name');
+
+        var columnDefinitions = tableDefinition.columnDefinitions;
+
+        // Validate the specified column types
+        for (var columnName in columnDefinitions) {
+            var columnType = columnDefinitions[columnName];
+
+            Validate.isString(columnType, 'columnType');
+            Validate.notNullOrEmpty(columnType, 'columnType');
+        }
+
+        this._db.transaction(function(transaction) {
+
+            var pragmaStatement = _.format("PRAGMA table_info({0});", tableDefinition.name);
+
+            transaction.executeSql(pragmaStatement, [], function (transaction, result) {
+
+                // If table already exists, add missing columns, if any.
+                // Else, create the table
+                if (result.rows.length > 0) {
+
+                    // Columns that are present in the table already
+                    var existingColumns = {};
+
+                    // Remove columns that are already present in the table from the columnDefinitions array
+                    for (var i = 0; i < result.rows.length; i++) {
+                        var column = result.rows.item(i);
+                        existingColumns[column.name] = true;
+                    }
+
+                    addMissingColumns(transaction, tableDefinition, existingColumns);
+
+                } else {
+                    createTable(transaction, tableDefinition);
+                }
+            });
+
+        }, function (error) {
+            callback(error);
+        }, function(result) {
+            callback();
+        });
+    });
+
+    //TODO(shrirs): instance needs to be an array instead of an object
+    this.upsert = Platform.async(function (tableName, instance, callback) {
+        /// <summary>Updates or inserts an object in the local table</summary>
+        /// <param name="tableName">Name of the local table in which the object is to be upserted</param>
+        /// <param name="instance">Object to be inserted or updated in the table</param>
+        /// <returns type="Promise">
+        /// A promise that is resolved when the operation is completed successfully.
+        /// If the operation fails, the promise is rejected
+        /// </returns>
+
+        // Platform.async silently appends a callback argument to the original list of arguments.
+        // Validate the argument length to ensure the callback argument is indeed the callback 
+        // provided by Platform.async.
+        Validate.length(arguments, 3, 'arguments');
+
+        Validate.isString(tableName, 'tableName');
+        Validate.notNullOrEmpty(tableName, 'tableName');
+
+        Validate.notNull(instance, 'instance');
+
+        // Note: The default maximum number of parameters allowed by sqlite is 999
+        // See: http://www.sqlite.org/limits.html#max_variable_number
+        // TODO(shrirs): Add support for tables with more than 999 columns
+
+        var columnNames = [];
+        var columnValues = [];
+
+        for (var property in instance) {
+            columnNames.push(property);
+            columnValues.push(instance[property]);
+        }
+
+        // Form string of the following form: ?,?,?,?....,?,? with one '?' for each column
+        var valueClause = Array(columnNames.length + 1).join('?').split('').join();
+
+        var insertStatement = _.format("INSERT OR REPLACE INTO {0} ({1}) VALUES ({2})", tableName, columnNames.join(), valueClause);
+
+        this._db.transaction(function(transaction) {
+            transaction.executeSql(insertStatement, columnValues);
+        }, function(error) {
+            callback(error);
+        }, function() {
+            callback();
+        });
+    });
+
+    // TODO(shrirs): Implement equivalents of readWithQuery and deleteUsingQuery
+    this.lookup = Platform.async(function (tableName, id, callback) {
+        /// <summary>Perform a lookup against a local table</summary>
+        /// <param name="tableName">Name of the local table in which look up is to be performed</param>
+        /// <param name="id">ID of the object to be looked up</param>
+        /// <returns type="Promise">
+        /// A promise that is resolved with the looked up object when the operation is completed successfully.
+        /// If the operation fails, the promise is rejected
+        /// </returns>
+
+        // Platform.async silently appends a callback argument to the original list of arguments.
+        // Validate the argument length to ensure the callback argument is indeed the callback 
+        // provided by Platform.async.
+        Validate.length(arguments, 3, 'arguments');
+
+        Validate.isString(tableName, 'tableName');
+        Validate.notNullOrEmpty(tableName, 'tableName');
+
+        Validate.notNull(id, 'id');
+
+        var lookupStatement = _.format("SELECT * FROM [{0}] WHERE {1} = ? COLLATE NOCASE", tableName, idPropertyName);
+
+        this._db.executeSql(lookupStatement, [id], function (result) {
+
+            var instance = null;
+            if (result.rows.length !== 0) {
+                instance = result.rows.item(0); 
+            }
+
+            callback(null, instance);
+        }, function (err) {
+            callback(err);
+        });
+    });
+
+    //TODO(shrirs): instance needs to be an array instead of an object
+    this.del = Platform.async(function (tableName, instance, callback) {
+        /// <summary>The items to delete from the local table</summary>
+        /// <param name="tableName">Name of the local table in which delete is to be performed</param>
+        /// <param name="instance">Object to delete from the table</param>
+        /// <returns type="Promise">
+        /// A promise that is resolved when the operation is completed successfully.
+        /// If the operation fails, the promise is rejected
+        /// </returns>
+
+        var deleteStatement = _.format("DELETE FROM {0} WHERE {1} = ? COLLATE NOCASE", tableName, idPropertyName);
+
+        this._db.executeSql(deleteStatement, [instance[idPropertyName]], function (result) {
+            callback();
+        }, function(error) {
+            callback(error);
+        });
+    });
+};
+
+function createTable(transaction, tableDefinition) {
+    var columnDefinitions = tableDefinition.columnDefinitions;
+    var columnDefinitionClauses = [];
+
+    for (var columnName in columnDefinitions) {
+        var columnType = columnDefinitions[columnName];
+
+        var columnDefinitionClause = _.format("[{0}] {1}", columnName, columnType);
+
+        // TODO(shrirs): Handle cases where id property may be missing
+        if (columnName === idPropertyName) {
+            columnDefinitionClause += " PRIMARY KEY";
+        }
+
+        columnDefinitionClauses.push(columnDefinitionClause);
+    }
+
+    var createTableStatement = _.format("CREATE TABLE [{0}] ({1})", tableDefinition.name, columnDefinitionClauses.join());
+
+    transaction.executeSql(createTableStatement);
+}
+
+// Add missing columns to the table
+function addMissingColumns(transaction, tableDefinition, existingColumns) {
+
+    // SQLite does not support adding multiple columns using a single statement; Add one column at a time
+    var columnDefinitions = tableDefinition.columnDefinitions;
+    for (var columnName in columnDefinitions) {
+
+        // If this column does not already exist, we need to create it
+        if (!existingColumns[columnName]) {
+            var alterStatement = _.format("ALTER TABLE {0} ADD COLUMN {1} {2}", tableDefinition.name, columnName, columnDefinitions[columnName]);
+            transaction.executeSql(alterStatement);
+        }
+    }
+}
+
+// Valid SQL types
+MobileServiceSQLiteStore.ColumnType = {
+    NULL: "NULL",
+    INTEGER: "INTEGER",
+    REAL: "REAL",
+    TEXT: "TEXT",
+    BLOB: "BLOB"
+};
+
+// Export
+Platform.addToMobileServicesClientNamespace({ MobileServiceSQLiteStore: MobileServiceSQLiteStore });
+
+exports.MobileServiceSQLiteStore = MobileServiceSQLiteStore;

--- a/sdk/Javascript/src/Utilities/Validate.js
+++ b/sdk/Javascript/src/Utilities/Validate.js
@@ -4,7 +4,7 @@
 
 /// <reference path="C:\Program Files (x86)\Microsoft SDKs\Windows\v8.0\ExtensionSDKs\Microsoft.WinJS.1.0\1.0\DesignTime\CommonConfiguration\Neutral\Microsoft.WinJS.1.0\js\base.js" />
 /// <reference path="C:\Program Files (x86)\Microsoft SDKs\Windows\v8.0\ExtensionSDKs\Microsoft.WinJS.1.0\1.0\DesignTime\CommonConfiguration\Neutral\Microsoft.WinJS.1.0\js\ui.js" />
-/// <reference path="..\Generated\Zumo.DevIntellisense.js" />
+/// <reference path="..\Generated\MobileServices.DevIntellisense.js" />
 
 var _ = require('Extensions');
 var Platform = require('Platform');

--- a/sdk/Javascript/test/cordova/.gitignore
+++ b/sdk/Javascript/test/cordova/.gitignore
@@ -1,0 +1,4 @@
+platforms
+plugins
+generated
+External

--- a/sdk/Javascript/test/cordova/config.xml
+++ b/sdk/Javascript/test/cordova/config.xml
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='utf-8'?>
+<widget id="com.microsoft.zumo.test" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name>Cordova UTs</name>
+    <description>
+        Azure Mobile Apps Cordova SDK UTs
+    </description>
+    <content src="index.html" />
+    <plugin name="cordova-plugin-whitelist" version="1" />
+    <access origin="*" />
+    <allow-intent href="http://*/*" />
+    <allow-intent href="https://*/*" />
+    <allow-intent href="tel:*" />
+    <allow-intent href="sms:*" />
+    <allow-intent href="mailto:*" />
+    <allow-intent href="geo:*" />
+    <platform name="android">
+        <allow-intent href="market:*" />
+    </platform>
+    <platform name="ios">
+        <allow-intent href="itms:*" />
+        <allow-intent href="itms-apps:*" />
+    </platform>
+    <engine name="windows" spec="^4.1.0" />
+</widget>

--- a/sdk/Javascript/test/cordova/www/index.html
+++ b/sdk/Javascript/test/cordova/www/index.html
@@ -1,0 +1,91 @@
+﻿<!DOCTYPE html>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<html>
+    <head>
+        <title>Azure Mobile Apps SDK Cordova UTs</title>
+        <link rel="stylesheet" type="text/css" href="js/External/qunit/qunit.css">
+        <link rel="stylesheet" type="text/css" href="css/Generated/styles.css">
+    </head>
+
+    <body>
+
+        <button id="edit-test-config">Configure</button>
+        <form id="test-config">
+            <fieldset>
+                <legend>Configuration</legend>
+                <p>
+                    <label>Runtime URI:</label>
+                    <input id="runtime-uri" name="runtime-uri" />
+                </p>
+                <button type="submit">Update</button>
+            </fieldset>
+        </form>
+
+        <!--
+        QUnit dynamically creates a toolbar and adds DOM nodes to it. However, adding dynamic
+        content is not supported on Windows 8.1 (Details: http://go.microsoft.com/fwlink/?LinkID=247104).
+        MSApp.execUnsafeLocalFunction() can be used to disable script filtering, but that will need changing QUnit code.
+
+        As a workaround, we add a div to filter calls to QUnit's toolbar. We do this by setting the id of the filter
+        div same as the id of QUnit's toolbar div and position it before QUnit's div in the DOM. 
+        The appendChild() method of the toolbar filter invokes appendChild() on QUnit's toolbar in a safe manner.
+
+        Note: Do not change the order of the following 2 divs.
+        -->
+        <div id='qunit-testrunner-toolbar'></div>
+        <div id="qunit"></div>
+
+        <script>
+            function id(name) {
+                return this.window.document.getElementById(name);
+            }
+
+            var toolbarId = "qunit-testrunner-toolbar",
+                toolbarFilter = id(toolbarId);
+
+            toolbarFilter.appendChild = function () {
+                var child = arguments[0];
+
+                // Safely add the child to the QUnit toolbar
+                MSApp.execUnsafeLocalFunction(function () {
+                    // Lookup QUnit's toolbar by setting the ID of the filter to ""
+                    toolbarFilter.id = "";
+                    var qunitToolbar = id("qunit-testrunner-toolbar");
+
+                    // Append the child to qunit's toolbar
+                    qunitToolbar.appendChild(child);
+
+                    // Start filtering method calls to the QUnit toolbar again
+                    toolbarFilter.id = toolbarId;
+                });
+            };
+        </script>
+
+        <script src="js/index.js"></script>
+
+        <script src="./js/External/qunit/qunit.js"></script>
+        <script src="cordova.js"></script>
+
+        <script src="js/generated/MobileServices.Web.Internals.js"></script>
+        <script src="js/generated/TestFrameworkAdapter.js"></script>
+        <script src="js/generated/TestClientHelper.js"></script>
+        <script src="js/generated/Tests.js"></script>
+    </body>
+</html>

--- a/sdk/Javascript/test/cordova/www/js/index.js
+++ b/sdk/Javascript/test/cordova/www/js/index.js
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+var app = {
+    // Application Constructor
+    initialize: function () {
+        this.bindEvents();
+    },
+    // Bind Event Listeners
+    //
+    // Bind any events that are required on startup. Common events are:
+    // 'load', 'deviceready', 'offline', and 'online'.
+    bindEvents: function () {
+        document.addEventListener('deviceready', this.onDeviceReady, false);
+    },
+    // deviceready Event Handler
+    //
+    // The scope of 'this' is the event. In order to call the 'receivedEvent'
+    // function, we must explicitly call 'app.receivedEvent(...);'
+    onDeviceReady: function () {
+        // Run the UTs
+        $run();
+    }
+};
+
+app.initialize();

--- a/sdk/Javascript/test/web/index.html
+++ b/sdk/Javascript/test/web/index.html
@@ -25,5 +25,10 @@
         <script src="js/TestFrameworkAdapter.js"></script>
         <script src="js/TestClientHelper.js"></script>
         <script src="generated/Tests.js"></script>
+
+        <script>
+            // Run the tests
+            $run();
+        </script>
     </body>
 </html>

--- a/sdk/Javascript/test/web/js/TestFrameworkAdapter.js
+++ b/sdk/Javascript/test/web/js/TestFrameworkAdapter.js
@@ -14,7 +14,16 @@
 
     global.$testGroup = function (groupName /*, test1, test2, ... */) {
         var testsArray = arguments.length > 1 ? Array.prototype.slice.call(arguments, 1) : null;
-        return new TestGroup(groupName, testsArray);
+        var testGroup = new TestGroup(groupName, testsArray);
+        global.$testGroups.push(testGroup);
+
+        return testGroup;
+    };
+
+    global.$run = function () {
+        for (var index = 0; index < global.$testGroups.length; index++) {
+            global.$testGroups[index].exec();
+        }
     };
 
     global.$assert = {
@@ -104,6 +113,8 @@
         return formatString;
     };
 
+    global.$testGroups = [];
+
     // ------------------------------------------------------------------------------
     // Test represents a single test
     function Test(testName) {
@@ -182,12 +193,15 @@
     TestGroup.prototype.functional = function () { return this; }; // Not used in browser - ignored
 
     TestGroup.prototype.tests = function (/* test1, test2, ... */) {
-        var testsArray = Array.prototype.slice.call(arguments, 0);
-        qunit.module(this.groupName);
-        for (var i = 0; i < testsArray.length; i++) {
-            testsArray[i].exec();
-        }
+        this.testsArray = Array.prototype.slice.call(arguments, 0);
         return this;
+    };
+
+    TestGroup.prototype.exec = function() {
+        qunit.module(this.groupName);
+        for (var i = 0; i < this.testsArray.length; i++) {
+            this.testsArray[i].exec();
+        }
     };
 
 })(this, this.QUnit);

--- a/sdk/Javascript/test/winJS/tests/unit/mobileServiceTables.js
+++ b/sdk/Javascript/test/winJS/tests/unit/mobileServiceTables.js
@@ -452,7 +452,7 @@ $testGroup('MobileServiceTables.js',
         var table = client.getTable('books');
         var originalModelObject = { price: 100 };
         return table.insert(originalModelObject, { state: 'CA' }).then(function (results) {
-            var isWinJs = typeof Windows === "object";
+            var isWinJs = Platform.getSdkInfo().language === "WinJS";
             if (isWinJs) {
                 // For backward compatibility, the WinJS client mutates the original model
                 // object by adding/overwriting properties from the server response
@@ -658,7 +658,7 @@ $testGroup('MobileServiceTables.js',
         var table = client.getTable('books');
         var originalModelObject = { id: 2, price: 100 };
         return table.update(originalModelObject, { state: 'AL' }).then(function (results) {
-            var isWinJs = typeof Windows === "object";
+            var isWinJs = Platform.getSdkInfo().language === "WinJS";
             if (isWinJs) {
                 // For backward compatibility, the WinJS client mutates the original model
                 // object by adding/overwriting properties from the server response
@@ -1146,7 +1146,7 @@ $testGroup('MobileServiceTables.js',
                 });
 
                 return client.getTable('books').refresh(originalModelObject).then(function (results) {
-                    var isWinJs = typeof Windows === "object";
+                    var isWinJs = Platform.getSdkInfo().language === "WinJS";
                     if (isWinJs) {
                         // For backward compatibility, the WinJS client mutates the original model
                         // object by adding/overwriting properties from the server response
@@ -1241,7 +1241,7 @@ $testGroup('MobileServiceTables.js',
         var originalModelObject = { id: 2, price: 100 };
 
         return table.refresh(originalModelObject).then(function (results) {
-            var isWinJs = typeof Windows === "object";
+            var isWinJs = Platform.getSdkInfo().language === "WinJS";
             if (isWinJs) {
                 // For backward compatibility, the WinJS client mutates the original model
                 // object by adding/overwriting properties from the server response
@@ -1278,7 +1278,7 @@ $testGroup('MobileServiceTables.js',
         var originalModelObject = { id: 2, price: 100 };
 
         return table.refresh(originalModelObject, {"name":"bob"}).then(function (results) {
-            var isWinJs = typeof Windows === "object";
+            var isWinJs = Platform.getSdkInfo().language === "WinJS";
             if (isWinJs) {
                 // For backward compatibility, the WinJS client mutates the original model
                 // object by adding/overwriting properties from the server response
@@ -1315,7 +1315,7 @@ $testGroup('MobileServiceTables.js',
         var originalModelObject = { id: 2, price: 100 };
 
         return table.refresh(originalModelObject).then(function (results) {
-            var isWinJs = typeof Windows === "object";
+            var isWinJs = Platform.getSdkInfo().language === "WinJS";
             if (isWinJs) {
                 // For backward compatibility, the WinJS client mutates the original model
                 // object by adding/overwriting properties from the server response

--- a/sdk/Javascript/test/winJS/tests/unit/mobileServicesClient._request.js
+++ b/sdk/Javascript/test/winJS/tests/unit/mobileServicesClient._request.js
@@ -127,8 +127,8 @@ $testGroup('MobileServiceClient._request',
     .checkAsync(function () {
         var client = new WindowsAzure.MobileServiceClient("http://www.windowsazure.com/", "http://www.gateway.com/", "123456abcdefg");
         client = client.withFilter(function (req, next, callback) {
-            var isWinJs = typeof Windows === "object",
-                isCordova = window && window.cordova && window.cordova.version;
+            var isWinJs = Platform.getSdkInfo().language === "WinJS",
+                isCordova = Platform.getSdkInfo().language === "Cordova";
 
             if (isWinJs) {
                 $assert.areEqual(0, req.headers['X-ZUMO-VERSION'].indexOf("ZUMO/1.3 (lang=WinJS; os=Windows 8; os_version=--; arch=Neutral; version="));


### PR DESCRIPTION
- Added a basic implementation of SQLite store based on litehelpers' SQLite
- Some TODOs are marked in code and needs to be taken care of.
- More UTs need to be added. This commit contains a single UT to test basic functionality.
- Tweaked the test framework adapter to start running the tests only when asked to do so. This makes it possible to trigger the tests when all required cordova plugins are loaded. WinRT implementation already does this
- QUnit adds new elements to the DOM which is not allowed in WinRT unless done in an 'unsafe' context. Implemented a hack to workaround this limitation without having to edit QUnit code. This implementation makes an implicit assumption on the QUnit code (that the only disallowed calls are the calls to the toolbar's appendChild() method)
- Ported the existing browser UTs to Cordova. Fixed some incorrect platform checks (isWinRT, etc).
