### PR TITLE
Incremental Update fetches all items

### DIFF
--- a/sdk/iOS/src/MSQueuePullOperation.m
+++ b/sdk/iOS/src/MSQueuePullOperation.m
@@ -305,7 +305,7 @@
     
     if (self.deltaToken) {
         MSDateOffset *offset = [[MSDateOffset alloc]initWithDate:self.deltaToken];
-        NSPredicate *updatedAt = [NSPredicate predicateWithFormat:@"%K >= %@", MSSystemColumnUpdatedAt, offset];
+        NSPredicate *updatedAt = [NSPredicate predicateWithFormat:@"%K > %@", MSSystemColumnUpdatedAt, offset];
         if (self.originalPredicate) {
             self.query.predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[self.originalPredicate, updatedAt]];
         }


### PR DESCRIPTION
When using sync tables and query id to get an incremental update the requests filters with greater than or equal witch results in all items being fetched again. Using iOS.

$skip=0&$filter=(__updatedAt%20ge%20datetimeoffset'2015-10-28T14%3A04%3A10.590Z')&$orderby=__updatedAt%20asc&__includeDeleted=true&$top=50&__systemProperties=__createdAt%2C__updatedAt%2C__deleted%2C__version